### PR TITLE
Direct application of Braga on the Ackermann function

### DIFF
--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -63,6 +63,7 @@ ackermann/ackermann_factored.v
 ackermann/ack2_ack2i.v
 ackermann/ack123.v
 ackermann/ack2_ack2i_orig.v
+ackermann/ackermann_lex2.v
 
 # Rose tree height via BFS
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -60,6 +60,7 @@ unif/unif_term.v
 ackermann/ackermann.v
 ackermann/ackermann_dm.v
 ackermann/ackermann_factored.v
+ackermann/ack2_ack2i.v
 
 # Utilities
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -55,6 +55,10 @@ unif/unif_fix.v
 unif/unif_partial_corr.v
 unif/unif_term.v
 
+# The Ackermann function, with termination in just 2 lines
+
+ackermann/ackermann.v
+
 # Utilities
 
 utils/measure_induction.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -59,6 +59,7 @@ unif/unif_term.v
 
 ackermann/ackermann.v
 ackermann/ackermann_dm.v
+ackermann/ackermann_factored.v
 
 # Utilities
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -58,6 +58,7 @@ unif/unif_term.v
 # The Ackermann function, with termination in just 2 lines
 
 ackermann/ackermann.v
+ackermann/ackermann_dm.v
 
 # Utilities
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -61,6 +61,7 @@ ackermann/ackermann.v
 ackermann/ackermann_dm.v
 ackermann/ackermann_factored.v
 ackermann/ack2_ack2i.v
+ackermann/ack123.v
 
 # Utilities
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -62,6 +62,7 @@ ackermann/ackermann_dm.v
 ackermann/ackermann_factored.v
 ackermann/ack2_ack2i.v
 ackermann/ack123.v
+ackermann/ack2_ack2i_orig.v
 
 # Utilities
 

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -18,6 +18,8 @@ with      ack3_spec : nat → nat → nat → Prop :=
 
 (* Le constructeur alternatif *)
 (* JFM: résidu inutile ? Ca compile sans *)
+(* DLW: juste pour montrer que c'est un type équilavent au type d'origine
+        mais effectivement, il ne sert pas ici *)
 (*Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
 Proof. constructor 2; auto; econstructor; eauto. Qed.
 *)

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -4,7 +4,7 @@ Require Import Utf8.
 
 Unset Elimination Schemes.
 
-(* On garde la forme existencielle ici, avec un prédicat spécialisé 
+(* On garde la forme existentielle ici, avec un prédicat spécialisé 
    en lieu et place de (∃x, ack2i_spec m n x ∧ ack2_spec m x y),
    ck ack2_ack2i.v *)
 Inductive ack1_spec : nat → nat → nat → Prop :=
@@ -17,8 +17,10 @@ with      ack3_spec : nat → nat → nat → Prop :=
 | ack3_nS {m n x} : ack1_spec (S m) n x → ack3_spec m (S n) x.
 
 (* Le constructeur alternatif *)
-Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
+(* JFM: résidu inutile ? Ca compile sans *)
+(*Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
 Proof. constructor 2; auto; econstructor; eauto. Qed.
+*)
 
 Lemma ack1_spec_inv {m n y} :
       ack1_spec m n y

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -75,6 +75,22 @@ Section ack123_spec_ind.
     | S n => λ a, HQS (ack3_spec_inv_S a) (ack1_spec_ind_alt (ack3_spec_inv_S a))
     end a.
 
+  (* Le même avec 3 fixpoints mutuels *) 
+  Fixpoint ack1_spec_ind_alt3 {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
+    match m return ack1_spec m _ _ → _ with
+    | 0   => λ a, match ack1_spec_inv a in _ = n return P _ _ n with eq_refl => HP0 end
+    | S m => λ a, ack2_spec_ind_alt3 (ack1_spec_inv_S a)
+    end a
+  with ack2_spec_ind_alt3 {m n x} (a : ack2_spec m n x) { struct a } : P (S m) n x :=
+    match a with
+    | ack2_in h1 h2 => HPS h1 (ack3_spec_ind_alt3 h1) h2 (ack1_spec_ind_alt3 h2)
+    end
+  with ack3_spec_ind_alt3 {m n x} (a : ack3_spec m n x) { struct a } : Q m n x :=
+    match n return ack3_spec _ n _ → _ with
+    | 0   => λ a, match ack3_spec_inv a in _ = n return Q _ _ n with eq_refl => HQ0 end
+    | S n => λ a, HQS (ack3_spec_inv_S a) (ack1_spec_ind_alt3 (ack3_spec_inv_S a))
+    end a.
+
   (** Voici le récurseur standard, qui a le même type, mais pas le même algo. *)
 
   Fixpoint ack1_spec_ind_std {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
@@ -88,6 +104,22 @@ Section ack123_spec_ind.
     match a with
     | ack3_n0   => HQ0
     | ack3_nS h => HQS h (ack1_spec_ind_std  h)
+    end.
+
+  (* Le même avec 3 fixpoints mutuels *) 
+  Fixpoint ack1_spec_ind_std3 {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
+    match a with
+    | ack1_m0   => HP0
+    | ack1_mS h => ack2_spec_ind_std3 h
+    end
+  with ack2_spec_ind_std3 {m n x} (a : ack2_spec m n x) { struct a } : P (S m) n x :=
+    match a with
+    | ack2_in h1 h2 => HPS h1 (ack3_spec_ind_std3 h1) h2 (ack1_spec_ind_std3 h2)
+    end
+  with ack3_spec_ind_std3 {m n x} (a : ack3_spec m n x) { struct a } : Q m n x :=
+    match a with
+    | ack3_n0   => HQ0
+    | ack3_nS h => HQS h (ack1_spec_ind_std3  h)
     end.
 
 End ack123_spec_ind.

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -1,4 +1,18 @@
-(** DLW: ceci est un retravail d'un code initial de David Monniaux *) 
+(** DLW: ceci est un retravail d'un code initial de David Monniaux *)
+(** Le schéma suivi pour regrouper les composantes de certains constructeurs
+    dans un inductif auxiliaire (ack2_spec) est apparenté au schéma suivi
+    pour les petites inversions à base d'inductifs partiels exposées en 2021
+    https://www-verimag.imag.fr/~monin/Talks/sir.pdf
+    et évoquées à TYPES'22
+    https://www-verimag.imag.fr/~monin/Publis/Docs/types22-smallinv.pdf
+
+    L'objectif ici est de permettre d'accéder dans le même match
+    aux deux sous-termes de la spec de ack (S m) (S n) y
+    pour alléger l'écriture du récurseur.
+ *)
+
+(* JFM -> DLW : le résumé ci-dessus correspond à ma perception, tu vérifies
+   quand même que cela te va, ou tu rectifies ? *)
 
 Require Import Utf8.
 
@@ -7,6 +21,7 @@ Unset Elimination Schemes.
 (* On garde la forme existentielle ici, avec un prédicat spécialisé 
    en lieu et place de (∃x, ack2i_spec m n x ∧ ack2_spec m x y),
    ck ack2_ack2i.v *)
+(* JFM -> DLW : typo ligne juste avant ? *)
 Inductive ack1_spec : nat → nat → nat → Prop :=
 | ack1_m0 {n} : ack1_spec 0 n (S n)
 | ack1_mS {m n y} : ack2_spec m n y → ack1_spec (S m) n y
@@ -16,13 +31,10 @@ with      ack3_spec : nat → nat → nat → Prop :=
 | ack3_n0 {m} : ack3_spec m 0 1
 | ack3_nS {m n x} : ack1_spec (S m) n x → ack3_spec m (S n) x.
 
-(* Le constructeur alternatif *)
-(* JFM: résidu inutile ? Ca compile sans *)
-(* DLW: juste pour montrer que c'est un type équilavent au type d'origine
-        mais effectivement, il ne sert pas ici *)
-(*Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
+(* Le constructeur alternatif, montrant que cette spec est équivalente
+   à celle d'origine *)
+Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
 Proof. constructor 2; auto; econstructor; eauto. Qed.
-*)
 
 Lemma ack1_spec_inv {m n y} :
       ack1_spec m n y

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -1,0 +1,103 @@
+(** DLW: ceci est un retravail d'un code initial de David Monniaux *) 
+
+Require Import Utf8.
+
+Unset Elimination Schemes.
+
+(* On garde la forme existencielle ici, avec un prédicat spécialisé 
+   en lieu et place de (∃x, ack2i_spec m n x ∧ ack2_spec m x y),
+   ck ack2_ack2i.v *)
+Inductive ack1_spec : nat → nat → nat → Prop :=
+| ack1_m0 {n} : ack1_spec 0 n (S n)
+| ack1_mS {m n y} : ack2_spec m n y → ack1_spec (S m) n y
+with      ack2_spec : nat → nat → nat → Prop :=
+| ack2_in {m n y x} : ack3_spec m n x → ack1_spec m x y → ack2_spec m n y
+with      ack3_spec : nat → nat → nat → Prop :=
+| ack3_n0 {m} : ack3_spec m 0 1
+| ack3_nS {m n x} : ack1_spec (S m) n x → ack3_spec m (S n) x.
+
+(* Le constructeur alternatif *)
+Fact ack1_mS' {m n x y} : ack3_spec m n x → ack1_spec m x y → ack1_spec (S m) n y.
+Proof. constructor 2; auto; econstructor; eauto. Qed.
+
+Lemma ack1_spec_inv {m n y} :
+      ack1_spec m n y
+    → match m with
+      | O   => S n = y
+      | S m => ack2_spec m n y
+      end.
+Proof. now intros []. Qed.
+
+Definition not0 n := match n with 0 => False | _ => True end.
+
+Definition ack1_spec_inv_S {m n y} (a : ack1_spec (S m) n y) : ack2_spec m n y :=
+  match a in ack1_spec m _ _ return not0 m → ack2_spec (pred m) _ _ with
+  | ack1_m0   => λ C, match C with end
+  | ack1_mS h => λ _, h
+  end I.
+
+(* Pas besoin d'inverser ack2, un simple match/destruct suffit *)
+
+Lemma ack3_spec_inv {m n x} :
+      ack3_spec m n x
+    → match n with
+      | O => 1 = x
+      | S n => ack1_spec (S m) n x
+      end.
+Proof. now intros []. Qed.
+
+Definition ack3_spec_inv_S {m n x} (a : ack3_spec m (S n) x) : ack1_spec (S m) n x :=
+  match a in ack3_spec _ n _ return not0 n → ack1_spec _ (pred n) _ with
+  | ack3_n0   => λ C, match C with end
+  | ack3_nS h => λ _, h
+  end I.
+
+Section ack123_spec_ind.
+
+  (** Ici le recurseur non standard, qui commence par un match sur m/n. *)
+
+  Variables (P Q : nat → nat → nat → Prop)
+            (HP0 : ∀ {n}, P 0 n (S n))
+            (HPS : ∀ {m n x y}, ack3_spec m n x → Q m n x → ack1_spec m x y → P m x y → P (S m) n y)
+            (HQ0 : ∀ {m}, Q m 0 1)
+            (HQS : ∀ {m n x}, ack1_spec (S m) n x → P (S m) n x → Q m (S n) x).
+
+  Fixpoint ack1_spec_ind_alt {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
+    match m return ack1_spec m _ _ -> _ with
+    | 0   => λ a, match ack1_spec_inv a in _ = n return P _ _ n with eq_refl => HP0 end
+    | S m => λ a, match ack1_spec_inv_S a with
+                  | ack2_in h1 h2 => HPS h1 (ack3_spec_ind_alt h1) h2 (ack1_spec_ind_alt h2)
+                  end
+    end a
+  with ack3_spec_ind_alt {m n x} (a : ack3_spec m n x) { struct a } : Q m n x :=
+    match n return ack3_spec _ n _ -> _ with
+    | 0   => λ a, match ack3_spec_inv a in _ = n return Q _ _ n with eq_refl => HQ0 end
+    | S n => λ a, HQS (ack3_spec_inv_S a) (ack1_spec_ind_alt (ack3_spec_inv_S a))
+    end a.
+
+  (** Voici le récurseur standard, qui a le même type, mais pas le même algo. *)
+
+  Fixpoint ack1_spec_ind_std m n x (a : ack1_spec m n x) { struct a } : P m n x
+      with ack3_spec_ind_std m n x (a : ack3_spec m n x) { struct a } : Q m n x.
+  Proof.
+    + destruct a as [ | m n y [ ] ]; eauto.
+    + destruct a; eauto.
+  Qed.
+
+End ack123_spec_ind.
+
+(* La même preuve que ack1_spec_det mais avec le recurseur factorisé: on
+   peut utiliser n'importe lequel entre ack1_spec_ind_{alt,std} *)
+Theorem ack2_spec_det_with_recursor m n r₁ r₂ : ack1_spec m n r₁ → ack1_spec m n r₂ → r₁ = r₂.
+Proof.
+  intros a; revert r₂; pattern m, n, r₁; revert m n r₁ a.
+  apply ack1_spec_ind_alt with (Q := λ m n r₁, ∀ r₂, ack3_spec m n r₂ → r₁ = r₂).
+  + now intros ? ? ->%ack1_spec_inv.
+  + intros ? ? ? ? _ IH1 _ IH2 ? H%ack1_spec_inv.
+    destruct H as [ m n r₂ r H1 H2 ].
+    apply IH1 in H1 as ->.
+    now apply IH2 in H2 as ->.
+  + now intros ? ? ->%ack3_spec_inv.
+  + now intros ? ? ? _ IH ? ?%ack3_spec_inv%IH.
+Qed.
+

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -63,14 +63,14 @@ Section ack123_spec_ind.
             (HQS : ∀ {m n x}, ack1_spec (S m) n x → P (S m) n x → Q m (S n) x).
 
   Fixpoint ack1_spec_ind_alt {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
-    match m return ack1_spec m _ _ -> _ with
+    match m return ack1_spec m _ _ → _ with
     | 0   => λ a, match ack1_spec_inv a in _ = n return P _ _ n with eq_refl => HP0 end
     | S m => λ a, match ack1_spec_inv_S a with
                   | ack2_in h1 h2 => HPS h1 (ack3_spec_ind_alt h1) h2 (ack1_spec_ind_alt h2)
                   end
     end a
   with ack3_spec_ind_alt {m n x} (a : ack3_spec m n x) { struct a } : Q m n x :=
-    match n return ack3_spec _ n _ -> _ with
+    match n return ack3_spec _ n _ → _ with
     | 0   => λ a, match ack3_spec_inv a in _ = n return Q _ _ n with eq_refl => HQ0 end
     | S n => λ a, HQS (ack3_spec_inv_S a) (ack1_spec_ind_alt (ack3_spec_inv_S a))
     end a.

--- a/theories/ackermann/ack123.v
+++ b/theories/ackermann/ack123.v
@@ -77,12 +77,18 @@ Section ack123_spec_ind.
 
   (** Voici le récurseur standard, qui a le même type, mais pas le même algo. *)
 
-  Fixpoint ack1_spec_ind_std m n x (a : ack1_spec m n x) { struct a } : P m n x
-      with ack3_spec_ind_std m n x (a : ack3_spec m n x) { struct a } : Q m n x.
-  Proof.
-    + destruct a as [ | m n y [ ] ]; eauto.
-    + destruct a; eauto.
-  Qed.
+  Fixpoint ack1_spec_ind_std {m n x} (a : ack1_spec m n x) { struct a } : P m n x :=
+    match a with
+    | ack1_m0   => HP0
+    | ack1_mS h => match h with
+                   | ack2_in h1 h2 => HPS h1 (ack3_spec_ind_std h1) h2 (ack1_spec_ind_std h2)
+                   end
+    end
+  with ack3_spec_ind_std {m n x} (a : ack3_spec m n x) { struct a } : Q m n x :=
+    match a with
+    | ack3_n0   => HQ0
+    | ack3_nS h => HQS h (ack1_spec_ind_std  h)
+    end.
 
 End ack123_spec_ind.
 

--- a/theories/ackermann/ack2_ack2i.v
+++ b/theories/ackermann/ack2_ack2i.v
@@ -15,6 +15,10 @@ with ack2i_spec : nat → nat → nat → Prop :=
 | ack2i_n0 {m} : ack2i_spec m 0 1
 | ack2i_nS {m n x} : ack2_spec (S m) n x → ack2i_spec m (S n) x.
 
+(* Le constructeur alternatif *)
+Fact ack2_mS' {m n x y} : ack2i_spec m n x → ack2_spec m x y → ack2_spec (S m) n y.
+Proof. constructor 2; eauto. Qed.
+
 Lemma ack2_spec_inv {m n y} :
       ack2_spec m n y
     → match m with

--- a/theories/ackermann/ack2_ack2i.v
+++ b/theories/ackermann/ack2_ack2i.v
@@ -1,0 +1,88 @@
+(** DLW: ceci est un retravail d'un code initial de David Monniaux *) 
+
+(* Unset Elimination Schemes. *)
+
+(* On garde la forme existencielle ici, au lieu de déplier et on 
+   a donc un type mutuellement inductif imbriqué avec ex(ists) et
+   and ("et" logique) *)
+Inductive ack2_spec : nat -> nat -> nat -> Prop :=
+| ack2_m0 : forall n, ack2_spec O n (S n)
+| ack2_mS : forall m n y, (exists x, ack2i_spec m n x /\ ack2_spec m x y) -> ack2_spec (S m) n y
+
+with ack2i_spec : nat -> nat -> nat -> Prop :=
+| ack2i_n0 : forall m, ack2i_spec m O (S O)
+| ack2i_nS : forall m n x, ack2_spec (S m) n x -> ack2i_spec m (S n) x.
+
+Lemma ack2_spec_inv {m n y} :
+    ack2_spec m n y ->
+      match m with
+      | O => y = (S n)
+      | S m => exists x, ack2i_spec m n x /\ ack2_spec m x y
+      end.
+Proof. now intros []. Qed.
+
+Definition not0 n := match n with 0 => False | _ => True end.
+
+Definition ack2_spec_inv_S {m n y} (a : ack2_spec (S m) n y) : exists x, ack2i_spec m n x /\ ack2_spec m x y :=
+  match a in ack2_spec m' _ _ return not0 m' -> exists x, ack2i_spec (pred m') _ x /\ ack2_spec (pred m') x _ with
+  | ack2_m0 _       => fun C => match C with end
+  | ack2_mS _ _ _ h => fun _ => h
+  end I.
+
+Lemma ack2i_spec_inv {m n x} :
+    ack2i_spec m n x ->
+    match n with
+    | O => x = (S O)
+    | S n => ack2_spec (S m) n x
+    end.
+Proof. now intros []. Qed.
+
+(* L'inversion ack2i_spec m (S n) x produit une simple valeur
+   donc le code de cette factorisation est bcp plus naturel que
+   ack_spec_inv ci-dessus. *)
+Definition ack2i_spec_inv_S {m n x} (a : ack2i_spec m (S n) x) : ack2_spec (S m) n x :=
+  match a in ack2i_spec _ n' _ return not0 n' -> ack2_spec _ (pred n') _ with
+  | ack2i_n0 _       => fun C => match C with end
+  | ack2i_nS _ _ _ h => fun _ => h
+  end I.
+
+(* La même idée de départ que DM:
+
+     induction mutuelle structurelle sur SPEC1 (resp. SPECi1)
+
+   mais on commence par un match sur m (resp. n) aussi lieu 
+   d'un match sur SPEC1.
+
+   On pourrait d'ailleurs faire ça aussi dans ce cas parce qu'on
+   est dans Prop, càd utiliser le récurseur standard sur les
+   inductif mutuel. C'est plus simple en fait, mais là ce n'est 
+   plus les petites inversions *)
+Fixpoint ack2_spec_det {m n r1 r2} (SPEC1 : ack2_spec m n r1) (SPEC2 : ack2_spec m n r2) {struct SPEC1 } : r1 = r2
+   with  ack2i_spec_det {m n r1 r2} (SPECi1 : ack2i_spec m n r1) (SPECi2 : ack2i_spec m n r2) {struct SPECi1} : r1 = r2.
+Proof.
+  + destruct m as [ | m ].
+    * apply ack2_spec_inv in SPEC1, SPEC2; simpl in *; now subst.
+    * revert SPEC1 SPEC2.
+      intros (x & SPECi1s & SPEC1s)%ack2_spec_inv_S          (* on a besoin de CE sous-terme strict *)
+             (x' & SPECi2s & SPEC2s)%ack2_spec_inv.          (* mais pas de celui là *)
+      apply ack2_spec_det with (1 := SPEC1s).                (* on utilise le sous-terme SPEC1s the SPEC1 *)
+      now destruct (ack2i_spec_det _ _ _ _ SPECi1s SPECi2s). (* et aussi le sous-terme SPECi1s to SPEC1 *)
+  + destruct n as [ | n ].
+    * apply ack2i_spec_inv in SPECi1, SPECi2; simpl in *; now subst.
+    * exact (ack2_spec_det _ _ _ _ (ack2i_spec_inv_S SPECi1) (ack2i_spec_inv SPECi2)).
+Qed.
+
+(*** On garde ça pour la petite histoire *)
+
+(* L'inversion a une forme "étrange" ici car la valeur de
+   retour doit être un triplet dépendant de la forme
+           exists x, P x /\ Q x 
+   Donc on lui donne la forme d'un principe d'induction *)
+Definition ack_spec_inv_S' (P : nat -> nat -> Prop) m n y : 
+       (forall x, ack2i_spec m n x -> ack2_spec m x y -> P n y)
+    -> ack2_spec (S m) n y -> P n y :=
+  fun f a => match a in ack2_spec m' n' y' return not0 m' -> (forall x : nat, ack2i_spec (pred m') n' x -> ack2_spec (pred m') x y' -> P n' y') -> P n' y' with
+  | ack2_m0 _             => fun C _ => match C with end
+  | ack2_mS m n y (ex_intro _ _ (conj h1 h2)) => fun _ f => f _ h1 h2
+  end I f.
+

--- a/theories/ackermann/ack2_ack2i_orig.v
+++ b/theories/ackermann/ack2_ack2i_orig.v
@@ -1,0 +1,101 @@
+(** DLW: ceci est un retravail d'un code initial de David Monniaux
+         en factorisant le recurseur mutuel. On peut utiliser soit
+         le récurseur de David, soit le récurseur standard. *) 
+
+Require Import Utf8.
+
+Unset Elimination Schemes.
+
+Inductive ack2_spec : nat → nat → nat → Prop :=
+| ack2_m0 {n} : ack2_spec 0 n (S n)
+| ack2_mS {m n x y} : ack2i_spec m n x → ack2_spec m x y → ack2_spec (S m) n y
+
+with ack2i_spec : nat → nat → nat → Prop :=
+| ack2i_n0 {m} : ack2i_spec m 0 1
+| ack2i_nS {m n x} : ack2_spec (S m) n x → ack2i_spec m (S n) x.
+
+(** Deux inversion non-structurelles *)
+
+Lemma ack2_spec_inv {m n y} :
+      ack2_spec m n y
+    → match m with
+      | O   => S n = y
+      | S m => ∃x, ack2i_spec m n x ∧ ack2_spec m x y
+      end.
+Proof. intros []; eauto. Qed.
+
+Lemma ack2i_spec_inv {m n x} :
+      ack2i_spec m n x 
+    → match n with
+      | O => 1 = x
+      | S n => ack2_spec (S m) n x
+      end.
+Proof. now intros []. Qed.
+
+(** Une inversion structurelle *)
+
+Definition not0 n := match n with 0 => False | _ => True end.
+
+(** ack2_spec_inv_S ne peut pas être écrite indépendement/factorisée
+    car elle retourne un triplet dépendent, cf ack123.v *)
+
+Definition ack2i_spec_inv_S {m n x} (a : ack2i_spec m (S n) x) : ack2_spec (S m) n x :=
+  match a in ack2i_spec _ n _ return not0 n → ack2_spec _ (pred n) _ with
+  | ack2i_n0   => λ C, match C with end
+  | ack2i_nS h => λ _, h
+  end I.
+
+Section ack2_spec_ind.
+
+  Variables (P Q : nat → nat → nat → Prop)
+            (HP0 : ∀ {n}, P 0 n (S n))
+            (HPS : ∀ {m n x y}, ack2i_spec m n x → Q m n x → ack2_spec m x y → P m x y → P (S m) n y)
+            (HQ0 : ∀ {m}, Q m 0 1)
+            (HQS : ∀ {m n x}, ack2_spec (S m) n x → P (S m) n x → Q m (S n) x).
+
+
+  (* Ceci est le récurseur utilisé dans le code de David, que l'on factorise
+     pour plus de lisibilité. Dans ce récurseur: 
+     - ack2_spec_inv_S est inlinée (elle renvoit un triplet dépendant)
+     - par contre ack2i_spec_inv peut elle être factorisée, cf ci-dessus *)
+
+  Fixpoint ack2_spec_ind {m n x} (a : ack2_spec m n x) {struct a}  : P m n x :=
+    match m return ack2_spec m _ _ → _ with
+    |   0 => λ a, match ack2_spec_inv a in _ = x return P _ _ x with eq_refl => HP0 end
+    | S m => λ a, match a in ack2_spec m _ _ return not0 m → P m _ _ with
+                  | ack2_m0       => λ C, match C with end
+                  | ack2_mS h1 h2 => λ _, HPS h1 (ack2i_spec_ind h1) h2 (ack2_spec_ind h2)
+                  end I
+    end a
+  with ack2i_spec_ind {m n x} (a : ack2i_spec m n x) {struct a} : Q m n x :=
+    match n return ack2i_spec _ n _ → _ with
+    |   0 => λ a, match ack2i_spec_inv a in _ = n return Q _ _ n with eq_refl => HQ0 end
+    | S n => λ a, let a' := ack2i_spec_inv_S a in HQS a' (ack2_spec_ind a')
+    end a.
+
+  (* Pour info, ceci est le récurseur mutuel standard *)
+  Fixpoint ack2_spec_ind_std {m n x} (a : ack2_spec m n x) {struct a} : P m n x :=
+    match a with
+    | ack2_m0       => HP0
+    | ack2_mS h1 h2 => HPS h1 (ack2i_spec_ind_std h1) h2 (ack2_spec_ind_std h2)
+    end
+  with ack2i_spec_ind_std {m n x} (a : ack2i_spec m n x) {struct a} : Q m n x :=
+    match a with
+    | ack2i_n0   => HQ0
+    | ack2i_nS h => HQS h (ack2_spec_ind_std h)
+    end.
+
+End ack2_spec_ind.
+
+(* La preuve de déterministe, par induction (mutuelle) structurelle le premier ack2_spec 
+   puis inversion dépendante sur le deuxième *) 
+Theorem ack2_spec_det_with_recursor m n r₁ r₂ : ack2_spec m n r₁ → ack2_spec m n r₂ → r₁ = r₂.
+Proof.
+  intros a; revert r₂; pattern m, n, r₁; revert m n r₁ a.
+  apply ack2_spec_ind with (Q := λ m n r₁, ∀ r₂, ack2i_spec m n r₂ → r₁ = r₂).
+  + now intros ? ? ->%ack2_spec_inv.
+  + now intros ? ? ? ? _ IH1 _ IH2 ? (? & <-%IH1 & ?%IH2)%ack2_spec_inv.
+  + now intros ? ? ->%ack2i_spec_inv.
+  + now intros ? ? ? _ IH ? ?%ack2i_spec_inv%IH.
+Qed.
+

--- a/theories/ackermann/ackermann.v
+++ b/theories/ackermann/ackermann.v
@@ -59,7 +59,7 @@ Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀{v}, Gack (S m) n v → Da
 Fixpoint ack_pwc m n (d : Dack m n) : sig (Gack m n).
 Proof.
   refine(match m, n return Dack m n → sig (Gack m n) with
-  |   0 , _   => λ _, exist _ (1+n) _
+  |   0 ,   _ => λ _, exist _ (1+n) _
   | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d)     in
                       exist _ o _
   | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
@@ -100,7 +100,7 @@ Proof.
   destruct G as (? & <-%IH1 & ?); eauto.
 Qed.
 
-(* Fixpoint equations come from Gack constructors 
+(* Fixpoint equations come from Gack constructors
    and Gack_[spec_fun] *)
 
 #[local] Hint Resolve ack_spec Gack_fun : core.
@@ -132,11 +132,11 @@ Inductive ack_sub_calls : nat*nat → nat*nat → Prop :=
 
 Arguments Acc_inv {_ _ _} _ {_}.
 
-(* We use Acc_inv that recover the sub-term for a proof of d : Acc ... *) 
+(* We use Acc_inv that recover the sub-term for a proof of d : Acc ... *)
 Fixpoint ack_pwc_Acc m n (d : Acc ack_sub_calls (m,n)) : sig (Gack m n).
 Proof.
   refine(match m, n return Acc ack_sub_calls (m,n) → sig (Gack m n) with
-  |   0 , _   => λ _, exist _ (1+n) _
+  |   0 ,   _ => λ _, exist _ (1+n) _
   | S m ,   0 => λ d, let (o,ho) := ack_pwc_Acc m 1 (Acc_inv d _)     in
                       exist _ o _
   | S m , S n => λ d, let (v,hv) := ack_pwc_Acc (S m) n (Acc_inv d _) in
@@ -145,16 +145,16 @@ Proof.
   end d); eauto.
 Defined.
 
-Lemma ack_sub_calls_inv p q : 
+Lemma ack_sub_calls_inv p q :
        ack_sub_calls p q 
      → match q with
        | (  0 ,   n) => False
        | (S m ,   0) => (m,1) = p
-       | (S m , S n) => (S m, n) = p
+       | (S m , S n) => (S m,n) = p
                       ∨ ∃v, Gack (S m) n v
                           ∧ (m,v) = p
        end.
-Proof. destruct 1; eauto. Qed. 
+Proof. destruct 1; eauto. Qed.
 
 Lemma ack_termination_Acc m n : Acc ack_sub_calls (m,n).
 Proof.
@@ -164,7 +164,8 @@ Proof.
   intros ? [ | (? & _ & ?)]%ack_sub_calls_inv; subst; auto.
 Qed.
 
-(* Then we can finish as in the case of Dack *)
+(** Then we can finish as in the case of Dack with the def of ack
+    and the fixpoint equations, and extraction *)
 
 
 

--- a/theories/ackermann/ackermann.v
+++ b/theories/ackermann/ackermann.v
@@ -1,0 +1,121 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             JF Monin                   [**]                *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                            [**] Affiliation Verimag -- UGA *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2.1 FREE SOFTWARE LICENSE AGREEMENT        *)
+(**************************************************************)
+
+Require Import Utf8 Extraction.
+
+Inductive Gack : nat → nat → nat → Prop :=
+  | Gack_0_n n       : Gack 0 n (1+n)
+  | Gack_S_0 m o     : Gack m 1 o
+                     → Gack (S m) 0 o
+  | Gack_S_S m n v o : Gack (S m) n v
+                     → Gack m v o
+                     → Gack (S m) (S n) o.
+
+Inductive Dack : nat → nat → Prop :=
+  | Dack_0_n n     : Dack 0 n
+  | Dack_S_0 {m}   : Dack m 1
+                   → Dack (S m) 0
+  | Dack_S_S {m n} : Dack (S m) n
+                   → (∀v, Gack (S m) n v → Dack m v)
+                   → Dack (S m) (S n).
+
+#[local] Hint Constructors Gack Dack : core.
+
+(* Small inversions for domain projections *)
+
+Definition is_S_0 m n := match m, n with | S _, 0   => True | _, _ => False end.
+Definition is_S_S m n := match m, n with | S _, S _ => True | _, _ => False end.
+
+Definition Dack_pi1 {m} (d : Dack (S m) 0) : Dack m 1 :=
+  match d in Dack m n return is_S_0 m n → Dack (pred m) _ with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ _, h
+  | Dack_S_S _ _ => λ C, match C with end
+  end I.
+
+Definition Dack_pi2 {m n} (d : Dack (S m) (S n)) : Dack (S m) n :=
+  match d in Dack m n return is_S_S m n → Dack _ (pred n) with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S h _ => λ _, h
+  end I.
+
+Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀{v}, Gack (S m) n v → Dack m v :=
+  match d in Dack m n return is_S_S m n → ∀v, Gack _ (pred n) v → Dack (pred m) v with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S _ h => λ _, h
+  end I.
+
+(* The fully specified Ackermann function *)
+Fixpoint ack_pwc m n (d : Dack m n) : sig (Gack m n).
+Proof.
+  refine(match m, n return Dack m n → sig (Gack m n) with
+  |   0 , _   => λ _, exist _ (1+n) _
+  | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d) in 
+                      exist _ o _
+  | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
+                          let (o,ho) := ack_pwc m v (Dack_pi3 d hv)  in
+                      exist _ o _
+  end d); eauto.
+Defined.
+
+(* Termination of ack. Lexicographic product is by nested induction *)
+Lemma ack_termination m n : Dack m n.
+Proof.
+  induction m in n |- *; eauto.
+  induction n; eauto.
+Qed.
+
+(* Now the definition of Ackermann, combined with termination
+   and stripped of its low-level spec *)
+Definition ack m n := proj1_sig (ack_pwc m n (ack_termination m n)).
+
+(* We recover the spec for ack *)
+Lemma ack_spec m n : Gack m n (ack m n).
+Proof. apply (proj2_sig _). Qed.
+
+(* Inversion lemma for Gack *)
+Fact Gack_inv m n o :
+        Gack m n o
+      → match m, n with
+        |   0 ,   _ => o = 1+n
+        | S m ,   0 => Gack m 1 o
+        | S m , S n => ∃v, Gack (S m) n v ∧ Gack m v o
+        end.
+Proof. destruct 1; eauto. Qed.
+
+(* Gack is a functional relation, via Gack_inv *)
+Lemma Gack_fun m n o₁ o₂ : Gack m n o₁ → Gack m n o₂ → o₁ = o₂.
+Proof.
+  induction 1 as [ | | ? ? ? ? _ IH1 _ ? ] in o₂ |- *; intros G%Gack_inv; auto.
+  destruct G as (? & <-%IH1 & ?); eauto.
+Qed.
+
+(* Fixpoint equations come from Gack constructors 
+   and Gack_[spec_fun] *)
+
+#[local] Hint Resolve ack_spec Gack_fun : core.
+
+Fact ack_fix_0n n : ack 0 n = 1+n.
+Proof. eauto. Qed.
+
+Fact ack_fix_S0 m : ack (S m) 0 = ack m 1.
+Proof. eauto. Qed.
+
+Fact ack_fix_SS m n : ack (S m) (S n) = ack m (ack (S m) n).
+Proof. eauto. Qed.
+
+(* Extraction is right on spot *)
+Extraction Inline ack_pwc.
+Extraction ack.
+
+

--- a/theories/ackermann/ackermann.v
+++ b/theories/ackermann/ackermann.v
@@ -73,7 +73,7 @@ Lemma ack_termination m n : Dack m n.
 Proof.
   induction m in n |- *; eauto.
   induction n; eauto.
-Qed.
+Defined.
 
 (* Now the definition of Ackermann, combined with termination
    and stripped of its low-level spec *)
@@ -166,5 +166,31 @@ Qed.
 (** Then we can finish as in the case of Dack with the def of ack
     and the fixpoint equations, and extraction *)
 
+(* ---------------------------------------------------------------------- *)
+(* Computation times *)
 
+(* Explicit program for termination certificates *)
+Definition ack_termination_expl : ∀ m n, Dack m n :=
+  fix loop_m m : ∀ n, Dack m n :=
+    match m with
+    | O   => Dack_0_n
+    | S m =>
+        let loopm := loop_m m in
+        fix loop_n n : Dack (S m) n :=
+          match n with
+          | O   => Dack_S_0 (loopm 1)
+          | S n => Dack_S_S (loop_n n) (λ v _, loopm v)
+          end
+    end.
 
+Definition ack_expl m n := proj1_sig (ack_pwc m n (ack_termination_expl m n)).
+
+(* Very small values as input provide much maller computation times *)
+Time Compute ack_termination_expl 3 2. (* 0.004 s *)
+Time Compute ack_expl 3 4. (* 0.002 s *)
+
+(* Larger values can be computed *)
+Time Compute ack_termination 9 9. (* 2.36 s *)
+Time Compute ack_termination_expl 9 9. (* 0.98 s *)
+Time Compute ack_expl 3 10. (* 8.7 s *)
+Time Compute ack 3 10. (* 8.1 s *)

--- a/theories/ackermann/ackermann.v
+++ b/theories/ackermann/ackermann.v
@@ -63,7 +63,7 @@ Proof.
   | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d) in 
                       exist _ o _
   | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
-                          let (o,ho) := ack_pwc m v (Dack_pi3 d hv)  in
+                      let (o,ho) := ack_pwc m v (Dack_pi3 d hv)  in
                       exist _ o _
   end d); eauto.
 Defined.

--- a/theories/ackermann/ackermann.v
+++ b/theories/ackermann/ackermann.v
@@ -202,7 +202,10 @@ Time Compute ack_expl 3 4. (* 0.002 s *)
     proofs perform the same computation ... 
 
     Btw I do not get stable enough times to compare. 
-    In the last try, the _expl version is 0.5% faster ... *) 
+    In the last try, the _expl version is 0.5% faster ... *)
+
+(** JFM: got similarly unstable results. *)
+
 Time Compute ack 3 10. (* 8.1 s *)
 Time Compute ack_expl 3 10. (* 8.7 s *)
 

--- a/theories/ackermann/ackermann_dm.v
+++ b/theories/ackermann/ackermann_dm.v
@@ -1,0 +1,173 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             JF Monin                   [**]                *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                            [**] Affiliation Verimag -- UGA *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2.1 FREE SOFTWARE LICENSE AGREEMENT        *)
+(**************************************************************)
+
+(* This is the variant following the approach of D. Moniaux.
+
+   In this variant of the domain predicate, the output value
+   of the nested call is recovered using an existential
+   quantifier ∃v, favoured over a universal quantifier ∀v.
+
+   This change has some (limited) consequences, mainly
+ 
+   - we now need functionality of Gack to perform rewrite
+     (this is a match on a proof of identity). This occurs
+     in the third projection of the domain predicate;
+
+   - and also, that the domain is included in the projection
+     of the graph: Dack m n → ex (Gack m n), while proving
+     termination. This can of course be proved using ack_pwc
+     itself.
+
+   DLW: I recall using a similar ∃-characterisation for
+   another example (possibly f91? or maybe unification?) 
+   in the early days of the discovery of the Braga method,
+   but later decided it was more cumbersome to work with 
+   that the ∀-characterisation.
+   Not sure it works so well when the function is indeed
+   partial and not total like Ackermann.
+*)
+
+Require Import Utf8 Extraction.
+
+Inductive Gack : nat → nat → nat → Prop :=
+  | Gack_0_n n       : Gack 0 n (1+n)
+  | Gack_S_0 m o     : Gack m 1 o
+                     → Gack (S m) 0 o
+  | Gack_S_S m n v o : Gack (S m) n v
+                     → Gack m v o
+                     → Gack (S m) (S n) o.
+
+Fact Gack_inv m n o :
+        Gack m n o
+      → match m, n with
+        |   0 ,   _ => o = 1+n
+        | S m ,   0 => Gack m 1 o
+        | S m , S n => ∃v, Gack (S m) n v ∧ Gack m v o
+        end.
+Proof. destruct 1; eauto. Qed.
+
+Lemma Gack_fun {m n o₁ o₂} : Gack m n o₁ → Gack m n o₂ → o₁ = o₂.
+Proof.
+  induction 1 as [ | | ? ? ? ? _ IH1 _ ? ] in o₂ |- *; intros G%Gack_inv; auto.
+  destruct G as (? & <-%IH1 & ?); eauto.
+Qed.
+
+(* The modification is on the second rule 
+   which is now ∃v, Gack (S m) n v ∧ Dack m v 
+   instead of   ∀v, Gack (S m) n v → Dack m v 
+   hence we get the rule
+
+    Dack_S_S {m n} : Dack (S m) n
+                   → (∃v, Gack (S m) n v ∧ Dack m v)
+                   → Dack (S m) (S n)
+
+   Notice that the ∃ can be stripped into
+
+    Dack_S_S {m n} : Dack (S m) n
+                   → ∀v, (Gack (S m) n v ∧ Dack m v)
+                        → Dack (S m) (S n)
+  
+   or equivalently, permuting ∀v with → ahead
+   and stripping away ∧ using Curry-Howard
+
+    Dack_S_S {m n v} : Dack (S m) n
+                     → Gack (S m) n v
+                     → Dack m v
+                     → Dack (S m) (S n)
+
+   which is the version favoured by DM.
+
+  Notice that all the variants can be worked out,
+  not just the last one.
+*)
+
+(* We modify the domain Dack here, as explained above *)
+Inductive Dack : nat → nat → Prop :=
+  | Dack_0_n n       : Dack 0 n
+  | Dack_S_0 {m}     : Dack m 1
+                     → Dack (S m) 0
+  | Dack_S_S {m n v} : Dack (S m) n
+                     → Gack (S m) n v
+                     → Dack m v
+                     → Dack (S m) (S n).
+
+Definition is_S_0 m n := match m, n with | S _, 0   => True | _, _ => False end.
+Definition is_S_S m n := match m, n with | S _, S _ => True | _, _ => False end.
+
+Definition Dack_pi1 {m} (d : Dack (S m) 0) : Dack m 1 :=
+  match d in Dack m n return is_S_0 m n → Dack (pred m) _ with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ _, h
+  | Dack_S_S _ _ _ => λ C, match C with end
+  end I.
+
+Definition Dack_pi2 {m n} (d : Dack (S m) (S n)) : Dack (S m) n :=
+  match d in Dack m n return is_S_S m n → Dack _ (pred n) with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S h _ _ => λ _, h
+  end I.
+
+(* We modify the proof here. Notice that we need Gack_fun *)
+Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀{v}, Gack (S m) n v → Dack m v :=
+  match d in Dack m n return is_S_S m n → ∀v, Gack _ (pred n) v → Dack (pred m) v with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S _ hv d' => λ _ _ hw,
+    match Gack_fun hv hw with
+    | eq_refl => d' 
+    end
+  end I.
+
+#[local] Hint Constructors Gack Dack : core.
+
+(* Unchanged *)
+Fixpoint ack_pwc m n (d : Dack m n) : sig (Gack m n).
+Proof.
+  refine(match m, n return Dack m n → sig (Gack m n) with
+  |   0 ,   _ => λ _, exist _ (1+n) _
+  | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d)     in
+                      exist _ o _
+  | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
+                      let (o,ho) := ack_pwc m v (Dack_pi3 d hv)  in
+                      exist _ o _
+  end d); eauto.
+Defined.
+
+(* In this approach, we need the map Dack m n → ex (Gack m n), 
+   hence we use ack_pwc *)
+Lemma ack_termination m n : Dack m n.
+Proof.
+  induction m in n |- *; eauto.
+  induction n; auto.
+  destruct ack_pwc with (1 := IHn); eauto.
+Qed.
+
+(* Unchanged bellow *)
+
+Definition ack m n := proj1_sig (ack_pwc m n (ack_termination m n)).
+
+Lemma ack_spec m n : Gack m n (ack m n).
+Proof. apply (proj2_sig _). Qed.
+
+#[local] Hint Resolve ack_spec Gack_fun : core.
+
+Fact ack_fix_0n n : ack 0 n = 1+n.
+Proof. eauto. Qed.
+
+Fact ack_fix_S0 m : ack (S m) 0 = ack m 1.
+Proof. eauto. Qed.
+
+Fact ack_fix_SS m n : ack (S m) (S n) = ack m (ack (S m) n).
+Proof. eauto. Qed.
+
+Extraction Inline ack_pwc.
+Extraction ack.

--- a/theories/ackermann/ackermann_dm.v
+++ b/theories/ackermann/ackermann_dm.v
@@ -27,9 +27,9 @@
      can of course be proved using ack_pwc itself.
 
    DLW: I recall using a similar ∃-characterisation for another
-   example (possibly f91? or maybe unification?)  in the early days of
+   example (possibly f91? or maybe unification?) in the early days of
    the discovery of the Braga method, but later decided it was more
-   cumbersome to work with that the ∀-characterisation.  Not sure it
+   cumbersome to work with that the ∀-characterisation. Not sure it
    works so well when the function is indeed partial and not total
    like Ackermann.
 
@@ -81,7 +81,7 @@ Qed.
     Dack_S_S {m n} : Dack (S m) n
                    → ∀v, (Gack (S m) n v ∧ Dack m v)
                         → Dack (S m) (S n)
-  
+
    or equivalently, permuting ∀v with → ahead
    and stripping away ∧ using Curry-Howard
 
@@ -90,11 +90,11 @@ Qed.
                      → Dack m v
                      → Dack (S m) (S n)
 
-   which icorresponds to the version initially proposed by DM.
+   which corresponds to the version initially 
+   proposed by DM.
 
-  Notice that all the variants can be worked out,
-  not just the last one.
-*)
+   Notice that all the variants can be worked out,
+   not just the last one. *)
 
 (* We modify the domain Dack here, as explained above *)
 Inductive Dack : nat → nat → Prop :=

--- a/theories/ackermann/ackermann_dm.v
+++ b/theories/ackermann/ackermann_dm.v
@@ -45,7 +45,7 @@
 Require Import Utf8 Extraction.
 
 Inductive Gack : nat → nat → nat → Prop :=
-  | Gack_0_n n       : Gack 0 n (1+n)
+  | Gack_0_n n       : Gack 0 n (S n)
   | Gack_S_0 m o     : Gack m 1 o
                      → Gack (S m) 0 o
   | Gack_S_S m n v o : Gack (S m) n v
@@ -55,7 +55,7 @@ Inductive Gack : nat → nat → nat → Prop :=
 Fact Gack_inv m n o :
         Gack m n o
       → match m, n with
-        |   0 ,   _ => o = 1+n
+        |   0 ,   _ => S n = o
         | S m ,   0 => Gack m 1 o
         | S m , S n => ∃v, Gack (S m) n v ∧ Gack m v o
         end.
@@ -118,8 +118,8 @@ Definition Dack_pi1 {m} (d : Dack (S m) 0) : Dack m 1 :=
 
 Definition Dack_pi2 {m n} (d : Dack (S m) (S n)) : Dack (S m) n :=
   match d in Dack m n return is_S_S m n → Dack _ (pred n) with
-  | Dack_0_n _   => λ C, match C with end
-  | Dack_S_0 h   => λ C, match C with end
+  | Dack_0_n _     => λ C, match C with end
+  | Dack_S_0 h     => λ C, match C with end
   | Dack_S_S h _ _ => λ _, h
   end I.
 

--- a/theories/ackermann/ackermann_dm.v
+++ b/theories/ackermann/ackermann_dm.v
@@ -9,30 +9,37 @@
 (*         CeCILL v2.1 FREE SOFTWARE LICENSE AGREEMENT        *)
 (**************************************************************)
 
-(* This is the variant following the approach of D. Moniaux.
+(* This is the variant following the approach of D. Monniaux.
 
-   In this variant of the domain predicate, the output value
-   of the nested call is recovered using an existential
-   quantifier ∃v, favoured over a universal quantifier ∀v.
+   In this variant of the domain predicate, the output value of the
+   nested call is recovered using an existential quantifier ∃v,
+   favoured over a universal quantifier ∀v.
 
-   This change has some (limited) consequences, mainly
+   This change has some (limited, in terms of development effort)
+   consequences, mainly
  
-   - we now need functionality of Gack to perform rewrite
-     (this is a match on a proof of identity). This occurs
-     in the third projection of the domain predicate;
+   - we now need functionality of Gack to perform rewrite (this is a
+     match on a proof of identity). This occurs in the third
+     projection of the domain predicate;
 
-   - and also, that the domain is included in the projection
-     of the graph: Dack m n → ex (Gack m n), while proving
-     termination. This can of course be proved using ack_pwc
-     itself.
+   - and also, that the domain is included in the projection of the
+     graph: Dack m n → ex (Gack m n), while proving termination. This
+     can of course be proved using ack_pwc itself.
 
-   DLW: I recall using a similar ∃-characterisation for
-   another example (possibly f91? or maybe unification?) 
-   in the early days of the discovery of the Braga method,
-   but later decided it was more cumbersome to work with 
-   that the ∀-characterisation.
-   Not sure it works so well when the function is indeed
-   partial and not total like Ackermann.
+   DLW: I recall using a similar ∃-characterisation for another
+   example (possibly f91? or maybe unification?)  in the early days of
+   the discovery of the Braga method, but later decided it was more
+   cumbersome to work with that the ∀-characterisation.  Not sure it
+   works so well when the function is indeed partial and not total
+   like Ackermann.
+
+   JFM: agreed, we first considered the ∃ approach.
+   Looking again at it, the corresponding termination certificate has
+   a very different contents: it explicitly contains a chain of all
+   intermediate witnesses (the outputs of nested calls), while the
+   version favoured in Braga with a nested ∀ contains none of them, it
+   just waits for such outputs instead, and can then be seen as a lazy
+   version of the ∃ certificate.
 *)
 
 Require Import Utf8 Extraction.
@@ -83,7 +90,7 @@ Qed.
                      → Dack m v
                      → Dack (S m) (S n)
 
-   which is the version favoured by DM.
+   which icorresponds to the version initially proposed by DM.
 
   Notice that all the variants can be worked out,
   not just the last one.
@@ -151,7 +158,7 @@ Proof.
   destruct ack_pwc with (1 := IHn); eauto.
 Qed.
 
-(* Unchanged bellow *)
+(* Unchanged below *)
 
 Definition ack m n := proj1_sig (ack_pwc m n (ack_termination m n)).
 

--- a/theories/ackermann/ackermann_exaggerate.v
+++ b/theories/ackermann/ackermann_exaggerate.v
@@ -27,6 +27,11 @@ Inductive Gack : nat → nat → nat → Prop :=
 
 Inductive Dack (n m : nat) : Prop := Dexagg : (∀ x y, Dack x y) → Dack n m.
 
+(* Sure you can *always* replace the domain with False ... 
+   Exagerate is a bit of an understatement here ;-) *)
+Fact Dack_False n m : Dack n m → False.
+Proof. induction 1; auto. Qed.
+
 Definition Dack_pi {m n} (d : Dack m n) : ∀ {x y}, Dack x y :=
   match d with
   | Dexagg _ _ f => f

--- a/theories/ackermann/ackermann_exaggerate.v
+++ b/theories/ackermann/ackermann_exaggerate.v
@@ -1,0 +1,63 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             JF Monin                   [**]                *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                            [**] Affiliation Verimag -- UGA *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2.1 FREE SOFTWARE LICENSE AGREEMENT        *)
+(**************************************************************)
+
+(* Implementation of the comment in ackermann_simple.v
+"Exaggerating a lot more, take a domain such as:"
+*)
+
+Require Import Utf8 Extraction.
+
+Inductive Gack : nat → nat → nat → Prop :=
+  | Gack_0_n n       : Gack 0 n (S n)
+  | Gack_S_0 m o     : Gack m 1 o
+                     → Gack (S m) 0 o
+  | Gack_S_S m n v o : Gack (S m) n v
+                     → Gack m v o
+                     → Gack (S m) (S n) o.
+
+#[local] Hint Constructors Gack : core.
+
+Inductive Dack (n m : nat) : Prop := Dexagg : (∀ x y, Dack x y) → Dack n m.
+
+Definition Dack_pi {m n} (d : Dack m n) : ∀ {x y}, Dack x y :=
+  match d with
+  | Dexagg _ _ f => f
+  end.
+
+(* The fully specified Ackermann function *)
+Fixpoint ack_pwc m n (d : Dack m n) : sig (Gack m n).
+Proof.
+  refine(match m, n return Dack m n → sig (Gack m n) with
+  |   0 ,   _ => λ _, exist _ (S n) _
+  | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi d)     in
+                      exist _ o _
+  | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi d) in
+                      let (o,ho) := ack_pwc m v (Dack_pi d)  in
+                      exist _ o _
+  end d); eauto.
+Defined.
+
+(* Of course no termination certificate can be prodided! *)
+Lemma no_ack_termination m n : Dack m n → False.
+Proof.
+  induction 1 as [m n d Hd]. exact (Hd 0 0).
+Qed.
+
+(* Now the definition of Ackermann, stripped of its low-level spec *)
+Definition ack m n (d : Dack m n) := proj1_sig (ack_pwc m n d).
+
+(* We recover the spec for ack *)
+Lemma ack_spec m n (d : Dack m n) : Gack m n (ack m n d).
+Proof. apply (proj2_sig _). Qed.
+
+(* Extraction as usual *)
+Extraction Inline ack_pwc.
+Extraction ack.

--- a/theories/ackermann/ackermann_factored.v
+++ b/theories/ackermann/ackermann_factored.v
@@ -29,7 +29,7 @@ Inductive Dack : nat → nat → Prop :=
 
 #[local] Hint Constructors Gack Dack : core.
 
-(* Small inversions for domain projections *)
+(** Small inversions for domain projections *)
 
 Definition is_S_0 m n := match m, n with | S _, 0   => True | _, _ => False end.
 Definition is_S_S m n := match m, n with | S _, S _ => True | _, _ => False end.
@@ -94,7 +94,7 @@ Proof. apply (proj2_sig _). Qed.
 Fact Gack_inv m n o :
         Gack m n o
       → match m, n with
-        |   0 ,   _ => o = 1+n
+        |   0 ,   _ => S n = o
         | S m ,   0 => Gack m 1 o
         | S m , S n => ∃v, Gack (S m) n v ∧ Gack m v o
         end.
@@ -104,7 +104,7 @@ Proof. destruct 1; eauto. Qed.
 Lemma Gack_fun m n o₁ o₂ : Gack m n o₁ → Gack m n o₂ → o₁ = o₂.
 Proof.
   induction 1 as [ | | ? ? ? ? _ IH1 _ ? ] in o₂ |- *; intros G%Gack_inv; auto.
-  destruct G as (? & <-%IH1 & ?); eauto.
+  destruct G as (? & []%IH1 & ?); eauto.
 Qed.
 
 (* Fixpoint equations come from Gack constructors
@@ -112,7 +112,7 @@ Qed.
 
 #[local] Hint Resolve ack_spec Gack_fun : core.
 
-Fact ack_fix_0n n : ack 0 n = 1+n.
+Fact ack_fix_0n n : ack 0 n = S n.
 Proof. eauto. Qed.
 
 Fact ack_fix_S0 m : ack (S m) 0 = ack m 1.

--- a/theories/ackermann/ackermann_factored.v
+++ b/theories/ackermann/ackermann_factored.v
@@ -61,17 +61,18 @@ Proof.
   refine (match m return Dack m _ → sig (Gack m _) with
   | 0   => λ _, exist _ (S n) _
   | S m => λ d, let (v,hv) :=
-                  match n return Dack _ n → { v | match n with 0 => v = 1 | S n => Gack (S m) n v end } with 
+                  match n return Dack _ n → sig (match n with 0 => eq 1 | S n => Gack (S m) n end) with
                   | 0   => λ _, exist _ 1 eq_refl
                   | S n => λ d, ack_pwc (S m) n (Dack_pi2 d)
                   end d in
-                let (o,ho) := ack_pwc m v _ in
+                let (o,ho) := ack_pwc m v
+                    (match n return Dack _ n → match n with 0 => eq 1 | S _ => _ end v → _ with
+                     | 0   => λ d hv, match hv with eq_refl => Dack_pi1 d end
+                     | S n => λ d hv, Dack_pi3 d hv
+                     end d hv) in
                 exist _ o _
   end d); eauto.
-  + destruct n; subst.
-    * apply (Dack_pi1 d).
-    * now apply (Dack_pi3 d).
-  + destruct n; subst; eauto.
+  destruct n; subst; eauto.
 Defined.
 
 (* Termination of ack. Lexicographic product is by nested induction *)

--- a/theories/ackermann/ackermann_factored.v
+++ b/theories/ackermann/ackermann_factored.v
@@ -112,6 +112,24 @@ Proof.
   destruct hv; eauto.
 Defined.
 
+Fixpoint ack_pwc'' m n (d : Dack m n) : sig (Gack m n).
+Proof.
+  destruct m as [ | m ].
+  + exists (S n); eauto.
+  + assert {v | Gack' m n v} as (v & hv).
+    * destruct n as [ | n ].
+      - exists 1; eauto.
+      - destruct (ack_pwc'' (S m) n) as (v & hv).
+        ++ now apply Dack_pi2.
+        ++ exists v; eauto.
+    * destruct (ack_pwc'' m v) as (o & ho).
+      - destruct hv.
+        ++ now apply Dack_pi1.
+        ++ eapply Dack_pi3; eauto.
+      - exists o.
+        destruct hv; eauto.
+Defined.
+
 (* Termination of ack. Lexicographic product is by nested induction *)
 Lemma ack_termination m n : Dack m n.
 Proof.
@@ -160,4 +178,4 @@ Proof. eauto. Qed.
 
 (* Extraction is right on spot *)
 Extraction Inline ack_pwc.
-Recursive Extraction ack ack_pwc'.
+Recursive Extraction ack ack_pwc' ack_pwc''.

--- a/theories/ackermann/ackermann_lex2.v
+++ b/theories/ackermann/ackermann_lex2.v
@@ -1,0 +1,258 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             JF Monin                   [**]                *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                            [**] Affiliation Verimag -- UGA *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2.1 FREE SOFTWARE LICENSE AGREEMENT        *)
+(**************************************************************)
+
+Require Import Wellfounded Utf8 Extraction.
+
+Inductive Gack : nat → nat → nat → Prop :=
+  | Gack_0_n n       : Gack 0 n (S n)
+  | Gack_S_0 m o     : Gack m 1 o
+                     → Gack (S m) 0 o
+  | Gack_S_S m n v o : Gack (S m) n v
+                     → Gack m v o
+                     → Gack (S m) (S n) o.
+
+Inductive Dack : nat → nat → Prop :=
+  | Dack_0_n n     : Dack 0 n
+  | Dack_S_0 {m}   : Dack m 1
+                   → Dack (S m) 0
+  | Dack_S_S {m n} : Dack (S m) n
+                   → (∀v, Gack (S m) n v → Dack m v)
+                   → Dack (S m) (S n).
+
+#[local] Hint Constructors Gack Dack : core.
+
+(** Small inversions for domain projections *)
+
+Definition is_S_0 m n := match m, n with | S _, 0   => True | _, _ => False end.
+Definition is_S_S m n := match m, n with | S _, S _ => True | _, _ => False end.
+
+Definition Dack_pi1 {m} (d : Dack (S m) 0) : Dack m 1 :=
+  match d in Dack m n return is_S_0 m n → Dack (pred m) _ with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ _, h
+  | Dack_S_S _ _ => λ C, match C with end
+  end I.
+
+Definition Dack_pi2 {m n} (d : Dack (S m) (S n)) : Dack (S m) n :=
+  match d in Dack m n return is_S_S m n → Dack _ (pred n) with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S h _ => λ _, h
+  end I.
+
+Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀{v}, Gack (S m) n v → Dack m v :=
+  match d in Dack m n return is_S_S m n → ∀v, Gack _ (pred n) v → Dack (pred m) v with
+  | Dack_0_n _   => λ C, match C with end
+  | Dack_S_0 h   => λ C, match C with end
+  | Dack_S_S _ h => λ _, h
+  end I.
+
+(* The fully specified Ackermann function *)
+Fixpoint ack_pwc m n (d : Dack m n) : sig (Gack m n).
+Proof.
+  refine(match m, n return Dack m n → sig (Gack m n) with
+  |   0 ,   _ => λ _, exist _ (S n) _
+  | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d)     in
+                      exist _ o _
+  | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
+                      let (o,ho) := ack_pwc m v (Dack_pi3 d hv)  in
+                      exist _ o _
+  end d); eauto.
+Defined.
+
+(** Detailed explanation of the termination of ack using
+    the lexicographic product of the successor relation *)
+
+(* lex2 (m,n) (m',n') encodes that the pair
+   (m,n) is smaller than the pair (m',n')
+   in the lexicographic product of the 
+   successor relation. *)
+Inductive lex2 : nat*nat → nat*nat → Prop :=
+  | lex2_lft m u v : lex2 (m,u) (S m,v)        (* (m,_) < (S m,_) *)
+  | lex2_rt m n :    lex2 (m,n) (m,S n).       (* (m,n) < (m,S n) *)
+
+Inductive lex2_inv_0S n : nat*nat → Prop :=
+  | lex2_inv_0S_intro : lex2_inv_0S n (0,n).
+
+Inductive lex2_inv_S0 m : nat*nat → Prop :=
+  | lex2_inv_S0_intro n : lex2_inv_S0 m (m,n).
+
+Inductive lex2_inv_SS m n : nat*nat → Prop :=
+  | lex2_inv_SS_intro1 n' : lex2_inv_SS m n (m,n')
+  | lex2_inv_SS_intro2 :    lex2_inv_SS m n (S m,n).
+
+Fact lex2_inv {p q} : 
+       lex2 p q
+     → match q with
+       | (0   , 0  ) => False
+       | (0   , S n) => lex2_inv_0S n p
+       | (S m , 0  ) => lex2_inv_S0 m p
+       | (S m , S n) => lex2_inv_SS m n p
+       end.
+Proof. destruct 1 as [ ? ? [] | [] ]; constructor. Defined.
+
+Theorem lex2_wf : well_founded lex2.
+Proof.
+  intros (m,n).
+  induction m in n |- *; induction n; constructor.
+  all: now intros _ []%lex2_inv.
+Defined.
+
+(* Termination of ack. *)
+Lemma ack_termination m n : Dack m n.
+Proof.
+  generalize (lex2_wf (m,n)).
+  revert m n.
+  refine (fix loop m n a { struct a } := _).
+  destruct m as [ | m ].
+  + constructor.
+  + destruct n as [ | n ].
+    * constructor.
+      apply loop, Acc_inv with (1 := a).
+      constructor.
+    * constructor.
+      - apply loop, Acc_inv with (1 := a).
+        constructor.
+      - intros v _.
+        apply loop, Acc_inv with (1 := a).
+        constructor.
+Defined.
+
+(* ---------------------------------------------------------------------- *)
+(* Computation times *)
+
+(* Explicit program for termination certificates *)
+Definition ack_termination_expl : ∀ m n, Dack m n :=
+  fix loop_m m : ∀ n, Dack m n :=
+    match m with
+    | O   => Dack_0_n
+    | S m =>
+        fix loop_n n : Dack (S m) n :=
+          match n with
+          | O   => Dack_S_0 (loop_m m 1)
+          | S n => Dack_S_S (loop_n n) (λ v _, loop_m m v)
+          end
+    end.
+
+(* Now the definition of Ackermann, combined with termination
+   and stripped of its low-level spec 
+   
+   The two versions of ack and ack_expl are there to compare
+   the computation time of the Ltac based termination proof
+   and of the program based version of the proof. *)
+Definition ack m n := proj1_sig (ack_pwc m n (ack_termination m n)).
+Definition ack_expl m n := proj1_sig (ack_pwc m n (ack_termination_expl m n)).
+
+(* We recover the spec for ack *)
+Lemma ack_spec m n : Gack m n (ack m n).
+Proof. apply (proj2_sig _). Qed.
+
+(* Inversion lemma for Gack *)
+Fact Gack_inv m n o :
+        Gack m n o
+      → match m, n with
+        |   0 ,   _ => S n = o
+        | S m ,   0 => Gack m 1 o
+        | S m , S n => ∃v, Gack (S m) n v ∧ Gack m v o
+        end.
+Proof. destruct 1; eauto. Qed.
+
+(* Gack is a functional relation, via Gack_inv *)
+Lemma Gack_fun m n o₁ o₂ : Gack m n o₁ → Gack m n o₂ → o₁ = o₂.
+Proof.
+  induction 1 as [ | | ? ? ? ? _ IH1 _ ? ] in o₂ |- *; intros G%Gack_inv; auto.
+  destruct G as (? & []%IH1 & ?); eauto.
+Qed.
+
+(* Fixpoint equations come from Gack constructors
+   and Gack_[spec_fun] *)
+
+#[local] Hint Resolve ack_spec Gack_fun : core.
+
+Fact ack_fix_0n n : ack 0 n = S n.
+Proof. eauto. Qed.
+
+Fact ack_fix_S0 m : ack (S m) 0 = ack m 1.
+Proof. eauto. Qed.
+
+Fact ack_fix_SS m n : ack (S m) (S n) = ack m (ack (S m) n).
+Proof. eauto. Qed.
+
+(* Extraction is right on spot *)
+Extraction Inline ack_pwc.
+Extraction ack.
+
+(* This alternate avoids tailored small inversions and
+   replaces them with the generic Acc_inv, so we get
+   a shorter proof.*)
+
+(* We define the sub-call/call relation inductivelly *)
+Inductive ack_sub_calls : nat*nat → nat*nat → Prop :=
+  | ack_sc_1 m     : ack_sub_calls (m,1) (S m,0)
+  | ack_sc_2 m n   : ack_sub_calls (S m,n) (S m, S n)
+  | ack_sc_3 m n v : Gack (S m) n v → ack_sub_calls (m,v) (S m,S n).
+
+#[local] Hint Constructors ack_sub_calls : core.
+
+Arguments Acc_inv {_ _ _} _ {_}.
+
+(* We use Acc_inv that recover the sub-term for a proof of d : Acc ... *)
+Fixpoint ack_pwc_Acc m n (d : Acc ack_sub_calls (m,n)) : sig (Gack m n).
+Proof.
+  refine(match m, n return Acc ack_sub_calls (m,n) → sig (Gack m n) with
+  |   0 ,   _ => λ _, exist _ (S n) _
+  | S m ,   0 => λ d, let (o,ho) := ack_pwc_Acc m 1 (Acc_inv d _)     in
+                      exist _ o _
+  | S m , S n => λ d, let (v,hv) := ack_pwc_Acc (S m) n (Acc_inv d _) in
+                      let (o,ho) := ack_pwc_Acc m v (Acc_inv d _)     in
+                      exist _ o _
+  end d); eauto.
+Defined.
+
+Fact acc_sub_calls_lex2 p q : ack_sub_calls p q → lex2 p q.
+Proof. induction 1; simpl; constructor. Qed.
+
+Lemma ack_termination_Acc : well_founded ack_sub_calls.
+Proof. apply wf_incl with (1 := acc_sub_calls_lex2), lex2_wf. Qed.
+
+(** Then we can finish as in the case of Dack with the def of ack
+    and the fixpoint equations, and extraction *)
+
+Print ack_termination.
+Print ack_termination_expl.
+
+(* Very small values as input provide much maller computation times *)
+Time Compute ack_termination_expl 3 2. (* 0.004 s *)
+Time Compute ack_expl 3 4. (* 0.002 s *)
+
+(** DLW: for some strange reason, the hand coded computation
+    of the value is slower than the one using the Ltac script.
+    I suspect the hand coded version does not have any opaque
+    part while the other one may have some non-critical bits
+    Opaque. I do not see any another reason because both
+    proofs perform the same computation ... 
+
+    Btw I do not get stable enough times to compare. 
+    In the last try, the _expl version is 0.5% faster ... *)
+
+(** JFM: got similarly unstable results. *)
+
+Time Compute ack 3 10. (* takes a very long time *)
+Time Compute ack_expl 3 10. (* 8.7 s *)
+
+
+(* Larger values can be computed *)
+(* Time Compute ack_termination 9 9. (* 2.36 s *)
+Time Compute ack_termination_expl 9 9. (* 0.98 s *) *)
+
+
+
+

--- a/theories/ackermann/ackermann_simple.v
+++ b/theories/ackermann/ackermann_simple.v
@@ -117,40 +117,6 @@ Proof.
   induction n; eauto.
 Defined.
 
-(* Explicit program for termination certificates *)
-(* "expl" stands both for "explicit" and "explanation" *)
-Definition ack_termination_expl : ∀ m n, Dack m n :=
-  fix loop_m m : ∀ n, Dack m n := 
-    match m with
-    | O   => Dack_0_n
-    | S m =>
-        let loopm := loop_m m in
-        fix loop_n n : Dack (S m) n :=
-          match n with
-          | O   => Dack_S_0 (loopm 1)
-          | S n => Dack_S_S (loop_n n) loopm
-          end
-    end.
-
-(*
-Here is the program developed in file ackermann.v:
-Definition ack_termination_expl : ∀ m n, Dack m n :=
-  fix loop_m m : ∀ n, Dack m n :=
-    match m with
-    | O   => Dack_0_n
-    | S m =>
-        let loopm := loop_m m in
-        fix loop_n n : Dack (S m) n :=
-          match n with
-          | O   => Dack_S_0 (loopm 1)
-          | S n => Dack_S_S (loop_n n) (λ v hv, loopm v)
-          end
-    end.
-There we discovered that hv, a proof of Gack (S m) n v, is unused.
-This suggests that Dack could be simplified as proposed in the current
-file. And without loss in Lemma ack_termination as just checked.
-*)
-
 (* Now the definition of Ackermann, combined with termination
    and stripped of its low-level spec *)
 Definition ack m n := proj1_sig (ack_pwc m n (ack_termination m n)).
@@ -193,3 +159,52 @@ Proof. eauto. Qed.
 (* Extraction is right on spot *)
 Extraction Inline ack_pwc.
 Extraction ack.
+
+(* ---------------------------------------------------------------------- *)
+(* Computation times *)
+
+(* Explicit program for termination certificates *)
+(* "expl" stands both for "explicit" and "explanation" *)
+Definition ack_termination_expl : ∀ m n, Dack m n :=
+  fix loop_m m : ∀ n, Dack m n := 
+    match m with
+    | O   => Dack_0_n
+    | S m =>
+        let loopm := loop_m m in
+        fix loop_n n : Dack (S m) n :=
+          match n with
+          | O   => Dack_S_0 (loopm 1)
+          | S n => Dack_S_S (loop_n n) loopm
+          end
+    end.
+
+(*
+Here is the program developed in file ackermann.v:
+Definition ack_termination_expl : ∀ m n, Dack m n :=
+  fix loop_m m : ∀ n, Dack m n :=
+    match m with
+    | O   => Dack_0_n
+    | S m =>
+        let loopm := loop_m m in
+        fix loop_n n : Dack (S m) n :=
+          match n with
+          | O   => Dack_S_0 (loopm 1)
+          | S n => Dack_S_S (loop_n n) (λ v hv, loopm v)
+          end
+    end.
+There we discovered that hv, a proof of Gack (S m) n v, is unused.
+This suggests that Dack could be simplified as proposed in the current
+file. And without loss in Lemma ack_termination as just checked.
+*)
+
+Definition ack_expl m n := proj1_sig (ack_pwc m n (ack_termination_expl m n)).
+
+(* Very small values as input provide much maller computation times *)
+Time Compute ack_termination_expl 3 2. (* 0.004 s *)
+Time Compute ack_expl 3 4. (* 0.002 s *)
+
+(* Larger values can be computed *)
+Time Compute ack_termination 9 9. (* 0.61 s *)
+Time Compute ack_termination_expl 9 9. (* 2.3 s *)
+Time Compute ack_expl 3 10. (* 9.6 s *)
+Time Compute ack 3 10. (* 8.2 s *)

--- a/theories/ackermann/ackermann_simple.v
+++ b/theories/ackermann/ackermann_simple.v
@@ -59,7 +59,17 @@ performing too many tasks: those tasks will be quickly performed
 and you have the result, yes, but WITHOUT providing any understanding 
 (the real meaning of intelligence) of what happens; even worse, 
 like here, HIDING what happens.
-*)
+
+(DLW) Modifying Dack to correspond to the induction principle
+actually used to show termination is very *NOT* Braga IHMO.
+Precisely because you do not want to know a priori why it
+terminates.
+
+The script "ack_termination" gives enough info on the proof.
+Induction on m (with n universally quantified), then on n.
+The rest is solved by eauto because it is so easy. I could
+have detailed it, or used info_auto or info_eauto to get the
+details. *)
 
 Inductive Dack : nat → nat → Prop :=
   | Dack_0_n n     : Dack 0 n
@@ -113,9 +123,12 @@ Defined.
 (* Termination of ack. Lexicographic product is by nested induction *)
 Lemma ack_termination m n : Dack m n.
 Proof.
-  induction m in n |- *; eauto.
-  induction n; eauto.
-Defined.
+  induction m in n |- *.
+  + info_trivial.
+  + induction n.
+    * info_auto.
+    * info_auto.
+Qed.
 
 (* Now the definition of Ackermann, combined with termination
    and stripped of its low-level spec *)

--- a/theories/ackermann/ackermann_simple.v
+++ b/theories/ackermann/ackermann_simple.v
@@ -22,16 +22,26 @@ Inductive Gack : nat → nat → nat → Prop :=
                      → Gack m v o
                      → Gack (S m) (S n) o.
 
-(* Inductive domain, without any reference to Gack, which NOT the
+(* Inductive domain, without any reference to Gack, which is NOT the
    standard Braga method.*)
 
 (*
-There is a pitfall here: it is always possible to remove G in the
+Warning: the point of this file is NOT to provide an alternative to
+the Braga method, or to replace ackermann.v, but 
+1) to present or recall a pitfall -- basically, ability to extract 
+the right code is not enough;    
+2) to remind and discuss the rôle of G within D;
+3) to explore how an when, starting with the Braga method, other 
+versions of the Coq code could be derived.
+
+About 2), there is a pitfall: it is always possible to remove G in the
 definition of the domain, as far as the DEFINITION of the function is
-concerned; but the big danger is that the domain will become much 
+concerned; but the big danger is that the domain will become much
 smaller than expected or even empty.
-(Exagerating a lot more, take a domain such as 
-Inductive Dack n m : Prop := Dack x y : Dack x y → Dack n m).
+
+Exaggerating a lot more, take a domain such as:
+Inductive Dack n m : Prop := Dack: (∀ x y, Dack x y) → Dack n m.
+See ackermann_exaggerate.v
 
 This is why it is important to look at actual termination, i.e. 
 Lemma ack_termination here.
@@ -53,23 +63,42 @@ lexicographix ordering (which is certainly not the case of the
 readers; but it is not the point here), you have an opportunity
 to discover it.
 
-I (JFM) see this as an intereresting take hom lesson against the
-temptation of letting whatever kind of "Artificial Intelligence" 
-performing too many tasks: those tasks will be quickly performed 
-and you have the result, yes, but WITHOUT providing any understanding 
-(the real meaning of intelligence) of what happens; even worse, 
-like here, HIDING what happens.
+I (JFM) see this as an intereresting take home lesson against the
+temptation of letting whatever kind of "Artificial Intelligence" (or
+more humbly, automation) performing too many tasks: those tasks will
+be quickly performed and you have the result, yes, but WITHOUT
+providing any understanding (the real meaning of intelligence) of what
+happens; even worse, like here, HIDING what happens.
 
 (DLW) Modifying Dack to correspond to the induction principle
 actually used to show termination is very *NOT* Braga IHMO.
 Precisely because you do not want to know a priori why it
 terminates.
+  (JFM) Agreed, it was even recalled (without detail, though) at
+  the beginning of the comment. I elaborate a little bit more
+  there.
 
 The script "ack_termination" gives enough info on the proof.
 Induction on m (with n universally quantified), then on n.
 The rest is solved by eauto because it is so easy. I could
 have detailed it, or used info_auto or info_eauto to get the
-details. *)
+details. 
+
+(JFM) Unless I miss smtg, (e)auto does NOT say what is used
+(hypotheses, hints...); my point is that when an hypothesis is 
+not used, this may provide an interesting information.
+Another typical example is when students use induction instead
+of destruct.
+
+BTW I would prefer to keep the v argument of Dack_pi3 explicit.
+(Similarly, m and n are kept explicit arguments of ack_pwc,
+though they could be made implicit).
+Here, making v implicit convoys the illusion that h works the
+same way as in Dack_pi2 and hides the lazy nature of this
+part of the termination certificate -- the very reason
+why ack_termination 9 9 is computed in a reasonable amount
+of time, in contrast with ack 9 9.
+*)
 
 Inductive Dack : nat → nat → Prop :=
   | Dack_0_n n     : Dack 0 n
@@ -100,7 +129,7 @@ Definition Dack_pi2 {m n} (d : Dack (S m) (S n)) : Dack (S m) n :=
   | Dack_S_S h _ => λ _, h
   end I.
 
-Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀{v}, Dack m v :=
+Definition Dack_pi3 {m n} (d : Dack (S m) (S n)) : ∀ v, Dack m v :=
   match d in Dack m n return is_S_S m n → ∀v, Dack (pred m) v with
   | Dack_0_n _   => λ C, match C with end
   | Dack_S_0 h   => λ C, match C with end
@@ -115,7 +144,7 @@ Proof.
   | S m ,   0 => λ d, let (o,ho) := ack_pwc m 1 (Dack_pi1 d)     in
                       exist _ o _
   | S m , S n => λ d, let (v,hv) := ack_pwc (S m) n (Dack_pi2 d) in
-                      let (o,ho) := ack_pwc m v (Dack_pi3 d)  in
+                      let (o,ho) := ack_pwc m v (Dack_pi3 d v)  in
                       exist _ o _
   end d); eauto.
 Defined.


### PR DESCRIPTION
Following an exercise started by David Monniaux, we use the Braga method to implement the [_Ackermann function_](https://en.wikipedia.org/wiki/Ackermann_function), prove its termination (in just two lines of Ltac). Here is the extracted code:

```ocaml
let rec ack m n =
  match m, n with
  |   0 ,   _ -> S n
  | S m ,   0 -> ack m (S 0)
  | S m , S n -> ack m (ack (S m) n))
``` 

In the file [`ackermann_factored.v`](theories/ackermann/ackermann_factored.v), there is the extraction of a much more difficult variant where the `match n` is factored between two branches:

```ocaml
let rec ack m n =
  match m with
  |   0 -> S n
  | S m -> ack m 
   (match n with
    |   0 -> S 0
    | S n -> ack (S m) n)
``` 