### PR TITLE
 Recursive terminal computation of the height of a rose tree via BFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ Two variants of the `head : α list -> α` partial function:
 * [`ns.v`](theories/ns/ns.v): unbounded search `ns` via custom domain predicates 
 * [`ns_acc.v`](theories/ns/ns_acc.v): unbounded search `ns` via `Acc`-based domain predicates
 
+### [Rose Tree height with Breadth First Search](theories/tree_height_via_bfs/height_via_bfs.v)
+
+As an exercise suggested by J.C. Filliâtre at JFLA'24:
+
+```ocaml 
+       
+    type rtree = | Rt of rtree list
+    
+    let rec rev_app l = function
+    | []   -> l
+    | x::m -> rev_app (x::l) m
+
+    let rtree_ht_bfs t =
+      let rec level h n = function
+      | []      -> next (S h) n
+      | Rt l::c -> level h (rev_app n l) c
+      and next h n = match n with
+      | [] -> h
+      | _  -> level h [] n
+      in level 0 [] [t] 
+```
+
+*[`height_via_bfs.v`](theories/tree_height_via_bfs/height_via_bfs.v)
+
 ### [Depth-First Search on an infinite graph `dfs`](theories/dfs)
 
 ```ocaml

--- a/README.md
+++ b/README.md
@@ -149,11 +149,14 @@ Two variants of the `head : α list -> α` partial function:
 
 ### [Rose Tree height with Breadth First Search](theories/tree_height_via_bfs/height_via_bfs.v)
 
-As an exercise suggested by J.C. Filliâtre at JFLA'24:
+As an exercise suggested by J.C. Filliâtre at JFLA'24, the computation of the
+height of a finitely branching tree (ie. _rose tree_) using a zigzagging BFS algorithm
+implemented using two mutually recursive functions `level`/`next`:
+* the program is proved correct by construction against the following spec:
+* `rtree_ht_bfs (Rt l) = 1+list_max rtree_ht_bfs l`
 
 ```ocaml 
-       
-    type rtree = | Rt of rtree list
+    type rtree = Rt of rtree list
     
     let rec rev_app l = function
     | []   -> l

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -55,6 +55,10 @@ unif/unif_fix.v
 unif/unif_partial_corr.v
 unif/unif_term.v
 
+# Rose tree height via BFS
+
+tree_height_via_bfs/height_via_bfs.v
+
 # Utilities
 
 utils/measure_induction.v

--- a/theories/tree_height_via_bfs/height_via_bfs.ml
+++ b/theories/tree_height_via_bfs/height_via_bfs.ml
@@ -1,57 +1,45 @@
+type 'a rtree = Rt of 'a * ('a rtree list);;
 
-let t1 = Tree (1,[Tree (2,[Tree (4,[]);Tree (5,[])]);Tree (3,[])]);;
+let t1 = Rt (1,[Rt (2,[Rt (4,[]);Rt (5,[])]);Rt (3,[])]);;
 
-let rec bfs a = function 
-| []            -> List.rev a
-| Tree (i,l)::m -> bfs (i::a) (m@l);;
+let leaf x = Rt (x,[]);;
+let left x t = Rt (x,[t;leaf 0]);;
+let right x t = Rt (x,[leaf 0;t]);;
 
-bfs [] [t1];;
-
-type 'a tree = Tree of 'a * ('a tree list);;
-
-let ht t =
-  let rec loop n = function
-  | []       -> n
-  | None::[] -> n
-  | None::m  -> loop (1+n) (m @ [None])
-  | Some (Tree (i,l))::m 
-             -> loop n (m @ List.map (fun t -> Some t) l)
-  in loop 0 [None;Some t];;
-
-(* Using JC idea of replacing None/Some with
-   two list, n(ext) level and c(urrent level,
-   and using the fact that the height does not
-   depend on the order between the siblings,
-   we can avoid external functions. The termination
-   could certainly be measure based. *)
-
-let rec rev_app a = function
-| []   -> a
-| x::l -> rev_app (x::a) l;;
-
-let ht t =
-  let rec level h n = function
-  | []            -> next h n 
-  | Tree (_,l)::c -> level h (rev_app n l) c
-  and next h n = match n with
-  | [] -> h 
-  | _  -> level (1+h) [] n
-  in level 1 [] [t];;
-
-let leaf = Tree (0,[]);;
-let left t = Tree (0,[t;leaf]);;
-let right t = Tree (0,[leaf;t]);;
-
-let tree_of_ht =
-  let rec loop b n =
-    if n = 1 then leaf
-    else (if b then left else right) (loop (not b) (n-1)) 
-  in loop true;;
+let rtree_of_ht i =
+  let rec loop i b n =
+    if n = 1 then leaf i
+    else (if b then left i else right i) (loop (1+i) (not b) (n-1)) 
+  in loop i true i;;
 
 let rec list_an a n =
   if n = 0 then []
   else a::list_an (a+1) (n-1);;
 
-let t n = Tree (0,List.map tree_of_ht (list_an 1 (n-1)));;
+let t n = Rt (0,List.map rtree_of_ht (list_an 1 (n-1)));;
 
-ht (tree_of_ht 200);;
+let rec rev_app a = function
+| []   -> a
+| x::l -> rev_app (x::a) l;;
+
+let rev_map f = 
+  let rec loop a = function
+  | []   -> a
+  | x::l -> loop (f x::a) l
+  in loop;;
+
+(** A recursive terminal BFS algorithm marking the nodes with
+    a pair composed of its height and its order in BFS traversal
+    order *)
+let bfs t =
+  let rec level h i a n = function
+  | []          -> next (1+h) i a (rev_app [] n)
+  | Rt (x,l)::c -> level h (1+i) ((x,(h,i))::a) (rev_app n l) c
+  and next h i a n = match n with
+  | [] -> rev_app [] a
+  | _  -> level h i a [] n
+  in level 0 0 [] [] [t];;
+
+let t2 = t 3;;
+bfs t2;;
+

--- a/theories/tree_height_via_bfs/height_via_bfs.ml
+++ b/theories/tree_height_via_bfs/height_via_bfs.ml
@@ -22,12 +22,6 @@ let rec rev_app a = function
 | []   -> a
 | x::l -> rev_app (x::a) l;;
 
-let rev_map f = 
-  let rec loop a = function
-  | []   -> a
-  | x::l -> loop (f x::a) l
-  in loop;;
-
 (** A recursive terminal BFS algorithm marking the nodes with
     a pair composed of its height and its order in BFS traversal
     order *)

--- a/theories/tree_height_via_bfs/height_via_bfs.ml
+++ b/theories/tree_height_via_bfs/height_via_bfs.ml
@@ -1,0 +1,57 @@
+
+let t1 = Tree (1,[Tree (2,[Tree (4,[]);Tree (5,[])]);Tree (3,[])]);;
+
+let rec bfs a = function 
+| []            -> List.rev a
+| Tree (i,l)::m -> bfs (i::a) (m@l);;
+
+bfs [] [t1];;
+
+type 'a tree = Tree of 'a * ('a tree list);;
+
+let ht t =
+  let rec loop n = function
+  | []       -> n
+  | None::[] -> n
+  | None::m  -> loop (1+n) (m @ [None])
+  | Some (Tree (i,l))::m 
+             -> loop n (m @ List.map (fun t -> Some t) l)
+  in loop 0 [None;Some t];;
+
+(* Using JC idea of replacing None/Some with
+   two list, n(ext) level and c(urrent level,
+   and using the fact that the height does not
+   depend on the order between the siblings,
+   we can avoid external functions. The termination
+   could certainly be measure based. *)
+
+let rec rev_app a = function
+| []   -> a
+| x::l -> rev_app (x::a) l;;
+
+let ht t =
+  let rec level h n = function
+  | []            -> next h n 
+  | Tree (_,l)::c -> level h (rev_app n l) c
+  and next h n = match n with
+  | [] -> h 
+  | _  -> level (1+h) [] n
+  in level 1 [] [t];;
+
+let leaf = Tree (0,[]);;
+let left t = Tree (0,[t;leaf]);;
+let right t = Tree (0,[leaf;t]);;
+
+let tree_of_ht =
+  let rec loop b n =
+    if n = 1 then leaf
+    else (if b then left else right) (loop (not b) (n-1)) 
+  in loop true;;
+
+let rec list_an a n =
+  if n = 0 then []
+  else a::list_an (a+1) (n-1);;
+
+let t n = Tree (0,List.map tree_of_ht (list_an 1 (n-1)));;
+
+ht (tree_of_ht 200);;

--- a/theories/tree_height_via_bfs/height_via_bfs.ml
+++ b/theories/tree_height_via_bfs/height_via_bfs.ml
@@ -33,7 +33,7 @@ let bfs t =
   | [] -> rev_app [] a
   | _  -> level h i a [] n
   in level 0 0 [] [] [t];;
-
+		
 let t2 = t 3;;
 bfs t2;;
 

--- a/theories/tree_height_via_bfs/height_via_bfs.v
+++ b/theories/tree_height_via_bfs/height_via_bfs.v
@@ -7,9 +7,9 @@
 (*             Mozilla Public License MPL v2.0                *)
 (**************************************************************)
 
-(** Following a discussion with JC Filliâtre, here is 
+(** Following a discussion with JC Filliâtre, here is
     a correct by construction recursive terminal algorithm 
-    for computing the height of an undecorated rose tree via 
+    for computing the height of an undecorated rose tree via
     a zizaging Breadth First Traversal.
 
       type rtree = Rt of rtree list
@@ -30,8 +30,8 @@
     "Surprise surprise" in the position where
      h should be increased.
 
-     In particular, I could not prove the following 
-     variant
+     In particular, I could not prove the correctness
+     of the following variant
 
         let rec level h n = function
         | []      -> next h n
@@ -41,8 +41,8 @@
         | _  -> level (S h) ...
         in level 1 [] [t]
 
-     correct. Possibly the spec was too cumbersome 
-     compared to the straightforward version above. *)
+     Possibly the spec was too cumbersome compared to 
+     the more straightforward version above. *)
 
 (** This file is self contained over StdLib *)
 
@@ -52,7 +52,7 @@ Import ListNotations.
 
 (** List sum and max utilities *)
 
-(* rev_app with arguments ordered as OCaml *)
+(* rev_app with arguments ordered as in OCaml *)
 Definition rev_app {X} :=
   fix loop (l m : list X) :=
     match m with
@@ -140,11 +140,11 @@ Section rtree_ht_via_bfs.
 
   with Gnext : nat → list rtree → nat → Prop :=
 
-  | Gnext_nil h :     Gnext h [] h
+  | Gnext_nil h :           Gnext h [] h
 
-  | Gnext_not h n o : n ≠ []
-                    → Glevel h [] n o
-                    → Gnext h n o
+  | Gnext_not h n o :       n ≠ []
+                          → Glevel h [] n o
+                          → Gnext h n o
   .
 
   Inductive Dlevel : nat → list rtree → list rtree → Prop :=
@@ -199,7 +199,7 @@ Section rtree_ht_via_bfs.
      level h n ⟨l⟩::c  ~~>  level h (rev_append n l) c
 
      We find a linear measure that decrease at
-     these two reduction steps :
+     the above two reduction steps:
      the sum of 
        1) total size of n and c
        2) the max of (1 + max height in n) and (max height in c) 
@@ -248,8 +248,6 @@ Section rtree_ht_via_bfs.
       in the fixpoint and does not introduce __/Obj.magic *)
   Definition Dlevel_pi2_inv {h n l c} (d : Dlevel h n (⟨l⟩::c)) : Dlevel h (rev_app n l) c.
   Proof. now inversion d. Defined.
-
-  Print Dlevel_pi2_inv.
 
   (** The below inversion the one actually used in the fixpoint,
       is readable and avoids __/Obj.magic as well *)
@@ -353,6 +351,8 @@ Section rtree_ht_via_bfs.
   Qed.
 
 End rtree_ht_via_bfs.
+
+Check rtree_ht_bfs_total_correctness.
 
 Extraction Inline level next.
 Recursive Extraction rtree_ht_bfs.

--- a/theories/tree_height_via_bfs/height_via_bfs.v
+++ b/theories/tree_height_via_bfs/height_via_bfs.v
@@ -1,0 +1,276 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*             Mozilla Public License MPL v2.0                *)
+(**************************************************************)
+
+(** Following a discussion with JC Filliâtre, here is a correct
+    by construction recursive terminal algorithm 
+    for computing the height of an undecorated rose tree via 
+    a zizaging Breadth First Traversal. *)
+
+(** This file is slef contained over StdLib *)
+
+From Coq Require Import Arith Max Lia List Wellfounded Extraction Utf8.
+
+Import ListNotations.
+
+(** List sum and max utilities *)
+
+Section list_sum_max.
+
+  Variables (X : Type) (f : X → nat).
+
+  Fixpoint list_sum l :=
+    match l with
+    | []   => 0
+    | x::l => f x + list_sum l
+    end.
+
+  Fact list_sum_cons x l : list_sum (x::l) = f x + list_sum l.
+  Proof. reflexivity. Qed.
+
+  Fact list_sum_rev_append l m : list_sum (rev_append l m) = list_sum l + list_sum m.
+  Proof. induction l as [ | x l IHl ] in m |- *; simpl; auto; rewrite IHl; simpl; lia. Qed.
+
+  Fixpoint list_max l :=
+    match l with
+    | []   => 0
+    | x::l => Nat.max (f x) (list_max l)
+    end.
+
+  Fact list_max_cons x l : list_max (x::l) = Nat.max (f x) (list_max l).
+  Proof. reflexivity. Qed.
+
+  Fact list_max_rev_append l m : list_max (rev_append l m) = Nat.max (list_max l) (list_max m).
+  Proof. induction l as [ | x l IHl ] in m |- *; simpl; auto; rewrite IHl; simpl; lia. Qed.
+
+End list_sum_max.
+
+Arguments list_sum {_}.
+Arguments list_max {_}.
+
+(** Well foundedness utilities for termination *)
+
+Section measure3_rect.
+
+  Variable (X Y Z M : Type) (R : M → M → Prop) (HR : well_founded R)
+           (m : X → Y → Z → M) (P : X → Y → Z → Type).
+
+  Hypothesis F : (∀ x y z, (∀ x' y' z', R (m x' y' z') (m x y z) → P x' y' z') → P x y z).
+
+  Arguments F : clear implicits.
+
+  Let m' (c : X * Y * Z) := match c with (x,y,z) => m x y z end.
+
+  Notation R' := (λ c d, R (m' c) (m' d)).
+  Local Fact Rwf : well_founded R'.
+  Proof. apply wf_inverse_image with (f := m'), HR. Qed.
+
+  Definition measure3_rect x y z : P x y z :=
+    (fix loop x y z (a : Acc R' (x,y,z)) { struct a } := 
+      F x y z (λ x' y' z' H', loop x' y' z' (@Acc_inv _ _ _ a (_,_,_) H'))) _ _ _ (Rwf (_,_,_)).
+
+End measure3_rect.
+
+Tactic Notation "induction" "on" hyp(x) hyp(y) hyp(z) "as" ident(IH) "with" "wf" constr(wf) "and" "measure" uconstr(f) :=
+   pattern x, y, z; revert x y z; apply measure3_rect with (1 := wf) (m := λ x y z, f); intros x y z IH.
+
+Inductive nat_lex : nat*nat -> nat*nat -> Prop :=
+| nat_lex_lft a b c d : a < c → nat_lex (a,b) (c,d)
+| nat_lex_rt  a b c d : a = c → b < d → nat_lex (a,b) (c,d).
+
+Lemma nat_lex_wf : well_founded nat_lex.
+Proof.
+  intros (x,y).
+  induction x in y |- * using (well_founded_induction lt_wf).
+  induction y using (well_founded_induction lt_wf).
+  constructor; inversion 1; subst; eauto.
+Qed.
+
+(** The type of undecorated rose trees *)
+
+Unset Elimination Schemes.
+Inductive rtree := rt : list rtree -> rtree.
+Set Elimination Schemes.
+
+#[local] Notation "⟨ l ⟩" := (rt l).
+
+(* This is the non recursive terminal way of computing the size, via dfs *)
+Fixpoint rtree_sz t :=
+  match t with 
+  | ⟨l⟩ => S (list_sum rtree_sz l)
+  end.
+
+(* This is the non recursive terminal way of computing the height, via dfs *)
+Fixpoint rtree_ht t :=
+  match t with 
+  | ⟨l⟩ => S (list_max rtree_ht l)
+  end.
+
+Fact rtree_ht_ge_1 t : 1 ≤ rtree_ht t.
+Proof. destruct t; simpl; lia. Qed.
+
+Section rtree_ht_via_bfs.
+
+  (** Extraction of
+
+      type rtree = Rt of rtree list
+
+      let rtree_ht_bfs t =
+        let rec level h n = function
+        | []      -> next (S h) n
+        | Rt l::c -> level h (rev_app n l) c
+        and next h n = match n with
+        | [] -> h
+        | _  -> level h [] n
+        in level 1 [] [t];; 
+
+     "Surprise surprise" in the position where
+        h should be increased ... *)
+
+  Implicit Types (h o : nat) (n c : list rtree).
+
+  Inductive Glevel : nat → list rtree → list rtree → nat → Prop :=
+
+  | Glevel_nil h n o :      Gnext (S h) n o
+                          → Glevel h n [] o
+
+  | Glevel_cons h n l c o : Glevel h (rev_append l n) c o
+                          → Glevel h n (⟨l⟩::c) o
+
+  with Gnext : nat → list rtree → nat → Prop :=
+
+  | Gnext_nil h :     Gnext h [] h
+
+  | Gnext_not h n o : n ≠ []
+                    → Glevel h [] n o
+                    → Gnext h n o
+  .
+
+  Inductive Dlevel : nat → list rtree → list rtree → Prop :=
+
+  | Dlevel_nil h n :      Dnext (S h) n
+                        → Dlevel h n []
+
+  | Dlevel_cons h n l c : Dlevel h (rev_append l n) c
+                        → Dlevel h n (⟨l⟩::c)
+
+  with Dnext : nat → list rtree → Prop :=
+
+  | Dnext_nil h :   Dnext h []
+
+  | Dnext_not h n : n ≠ []
+                  → Dlevel h [] n
+                  → Dnext h n
+  .
+
+  Hint Constructors Glevel Gnext : core.
+
+  (** Partial correctness of level/next *)
+
+  Fixpoint level_partial_correctness h n c o (d : Glevel h n c o) { struct d } :
+
+       o = h + Nat.max (1+list_max rtree_ht n) (list_max rtree_ht c)
+
+  with next_partial_correctness h n o (d : Gnext h n o) { struct d } :
+
+       o = h + list_max rtree_ht n.
+
+  Proof.
+  + destruct d as [ h n o H | h n l c o H ].
+    * apply next_partial_correctness in H.
+      simpl; lia.
+    * apply level_partial_correctness in H.
+      rewrite list_max_rev_append in H.
+      rewrite list_max_cons; simpl rtree_ht.
+      lia.
+  + destruct d as [ h | h n o Hn Ho ].
+    * simpl; lia. 
+    * apply level_partial_correctness in Ho.
+      simpl list_max in Ho.
+      rewrite Nat.max_r in Ho; [ lia | ].
+      destruct n as [ | x n ]; [ easy | ].
+      generalize (rtree_ht_ge_1 x); simpl; lia.
+  Qed.
+
+  (** Termination, ie totality of level *)
+
+  (* level h n []      ~~> level (S h) [] n is n <> []
+     level h n ⟨l⟩ᵣ::c ~~> level h (rev_append n l) c
+
+     hence the lexicographic product of 
+      1) total size of n and c
+      2) max of (1 + max height in n) and (max height in c)
+     decreases on recursive calls *)
+
+  Theorem level_terminates h n c : Dlevel h n c.
+  Proof.
+    induction on h n c as IH
+      with wf     nat_lex_wf
+      and measure (list_sum rtree_sz n + list_sum rtree_sz c, 
+                   Nat.max (1+list_max rtree_ht n) (list_max rtree_ht c)).
+    destruct c as [ | [l] c ].
+    + constructor.
+      case_eq n.
+      * constructor 1.
+      * intros r n' e; constructor 2; [ easy | rewrite <- e ].
+        apply IH.
+        constructor 2.
+        - lia.
+        - simpl plus.
+          apply Nat.max_lt_iff; left.
+          cut (1 <= list_max rtree_ht n); [ lia | ].
+          subst; simpl.
+          generalize (rtree_ht_ge_1 r); lia.
+    + constructor 2.
+      apply IH.
+      constructor 1.
+      rewrite list_sum_rev_append, list_sum_cons; simpl; lia.
+  Qed.
+
+  (** Implementation of the fully spec'd mutually recursive function 
+
+      DLW: the inversion can be replaced with small inversions *)
+
+  Local Fixpoint level h n c (d : Dlevel h n c) { struct d } : sig (Glevel h n c) 
+            with next h n (d : Dnext h n) { struct d } : sig (Gnext h n).
+  + refine (match c return Dlevel _ _ c → _ with
+    | []     => λ d, let (o,ho) := next (S h) n _ in
+                     exist _ o _
+    | ⟨l⟩::c => λ d, let (o,ho) := level h (rev_append l n) c _ in
+                     exist _ o _
+    end d); (eauto || now inversion d).
+  + refine (match n as n' return n = n' -> _ with
+    | []   => λ _, exist _ h _
+    | t::l => λ e, let (o,ho) := level h [] n _ in
+                   exist _ o _
+    end eq_refl); eauto.
+    * inversion d.
+      - exfalso; now subst.
+      - trivial.
+    * subst; now constructor 2.
+  Defined.
+
+  (* This is extracted to a recursive terminal way of computing the height, via bfs *)
+  Definition rtree_ht_bfs t := proj1_sig (level 0 [] [t] (level_terminates _ _ _)).
+
+  Corollary rtree_ht_bfs_spec t : Glevel 0 [] [t] (rtree_ht_bfs t).
+  Proof. apply (proj2_sig _). Qed.
+
+  Theorem rtree_ht_bfs_total_correctness t : rtree_ht_bfs t = rtree_ht t.
+  Proof.
+    generalize (rtree_ht_bfs_spec t).
+    intros ->%level_partial_correctness.
+    rewrite Nat.max_r.
+    + simpl; lia.
+    + simpl; generalize (rtree_ht_ge_1 t); lia.
+  Qed.
+
+End rtree_ht_via_bfs.
+
+Extraction Inline level next.
+Recursive Extraction rtree_ht_bfs.

--- a/theories/tree_height_via_bfs/height_via_bfs.v
+++ b/theories/tree_height_via_bfs/height_via_bfs.v
@@ -350,9 +350,17 @@ Section rtree_ht_via_bfs.
     + generalize (rtree_ht_ge_1 t); lia.
   Qed.
 
+  Hint Resolve rtree_ht_bfs_total_correctness : core.
+
+  Corollary rtree_ht_bfs_fix l : rtree_ht_bfs ⟨l⟩ = 1+list_max rtree_ht_bfs l.
+  Proof.
+    rewrite rtree_ht_bfs_total_correctness; simpl; f_equal.
+    symmetry; induction l; simpl; f_equal; auto.
+  Qed.
+
 End rtree_ht_via_bfs.
 
-Check rtree_ht_bfs_total_correctness.
+Check rtree_ht_bfs_fix.
 
 Extraction Inline level next.
 Recursive Extraction rtree_ht_bfs.


### PR DESCRIPTION
This PR is a follow-up of a discussion started with JC Filliâtre at JFLA 2024 about computing the height of trees using recursive terminal algorithms only. 

We extract a recursive terminal algorithm for computing the height of a _rose tree_ (ie finitely branching) using a breadth first search (BFS) zigzag traversal of the tree:

```ocaml

type rtree = Rt of rtree list

let rec rev_app l = function
| []   -> l
| x::m -> rev_app (x::l) m

let rtree_ht_bfs t =
  let rec level h n = function
  | []      -> level (S h) n
  | Rt l::c -> next h (rev_app n l) c
  and next h n = match n with
  | [] -> h
  | _  -> level h [] n
  in level 0 [] [t]
```

The algorithm is proved correct by construction via extraction of fully specified Coq code, following the Braga method.

In complement, not extracted right now but an interesting extension that _enumerates_ a rose tree by tagging each node with its height and order in left-right BFS traversal order, a possible improvement over @DmxLarchey  work with R. Matthes in 2019.

```ocaml

let bfs t =
  let rec level h i a n = function
  | []          -> next (1+h) i a (rev_app [] n)
  | Rt (x,l)::c -> level h (1+i) ((x,(h,i))::a) (rev_app n l) c
  and next h i a n = match n with
  | [] -> rev_app [] a
  | _  -> level h i a [] n
  in level 0 0 [] [] [t];;
``` 
